### PR TITLE
test/postgres: don't os.exit in innerTestMain function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ func innerTestMain(m *testing.M) int {
 	defer testPostgresServer.Cleanup()
 	if err != nil {
 		slog.Error("failed to start postgres", "error", err)
-		os.Exit(1)
+		return 1
 	}
 	return m.Run()
 }

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -8,8 +8,7 @@
 
         vendorHash = "sha256-X2gMvKQeAY7pVJYAP4O0Nq+seiSuGvPub26seCk0c80=";
 
-        # TODO: fix sandbox test
-        doCheck = false;
+        doCheck = true;
         nativeCheckInputs = [
           pkgs.postgresql
           pkgs.minio-client


### PR DESCRIPTION
os.exit is a bit of a foot gun and shut be not used in function that might rely on defer in the future.