### PR TITLE
Fix nix path-info parsing error for file store objects

### DIFF
--- a/client/nixstore.go
+++ b/client/nixstore.go
@@ -33,7 +33,7 @@ type RealisationInfo struct {
 
 // GetPathInfoRecursive queries Nix for path info including all dependencies.
 func GetPathInfoRecursive(ctx context.Context, storePaths []string) (map[string]*PathInfo, error) {
-	args := []string{"--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json"}
+	args := []string{"--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--"}
 	args = append(args, storePaths...)
 
 	cmd := exec.CommandContext(ctx, "nix", args...)


### PR DESCRIPTION
Prevents store paths from being interpreted as flake references by adding the standard `--` separator before path arguments. Without this, nix path-info attempts to parse file store objects as flakes and fails with "is not a flake (because it's not a directory)".