### PR TITLE
add gc service

### DIFF
--- a/client/pending_closure.go
+++ b/client/pending_closure.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -93,11 +92,8 @@ type commitPendingClosureRequest struct {
 }
 
 // CompletePendingClosure marks a closure as complete, sending narinfo metadata for server-side signing.
+// The narinfos map can be empty when all objects already exist (deduplication).
 func (c *Client) CompletePendingClosure(ctx context.Context, closureID string, narinfos map[string]NarinfoMetadata) error {
-	if len(narinfos) == 0 {
-		return errors.New("narinfos map cannot be empty")
-	}
-
 	reqURL := c.baseURL.JoinPath("api/pending_closures", closureID, "complete")
 
 	reqBody := commitPendingClosureRequest{

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -388,15 +388,6 @@ func (s *Service) CommitPendingClosureHandler(w http.ResponseWriter, r *http.Req
 		validKeys[key] = true
 	}
 
-	// Validate that narinfos map is non-empty only if the closure has valid objects
-	// If validObjectKeys is empty, the closure was likely cleaned up, so we should
-	// proceed to commitPendingClosure which will return the proper 404
-	if len(validObjectKeys) > 0 && len(req.Narinfos) == 0 {
-		http.Error(w, "no narinfo metadata provided", http.StatusBadRequest)
-
-		return
-	}
-
 	// Validate and process each narinfo
 	for objectKey, meta := range req.Narinfos {
 		// Validate objectKey belongs to this pending closure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed upload workflow to allow completing pending closures even when no narinfo metadata is present (e.g., after deduplication).
  * Eliminates erroneous 400 Bad Request responses in cases where valid pending objects exist but narinfo data is empty.
  * Client no longer blocks such requests, and the server now accepts and processes these commits successfully.
  * Improves reliability and user experience for edge cases with empty metadata during closure commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->