### PR TITLE
add landing page in s3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ linters:
     - lll
     - wsl
   settings:
+    misspell:
+      ignore-words:
+        - substituters
     tagliatelle:
       case:
         rules:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ niks3 implements the [Nix binary cache specification](https://nixos.org/manual/n
 
     # Signing keys for NAR signing
     signKeyFiles = [ "/run/secrets/niks3-signing-key" ];
+
+    # Public cache URL (optional) - if exposed via https
+    # Generates a landing page with usage instructions and public keys
+    # cacheUrl = "https://cache.example.com";
   };
 }
 ```

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -106,6 +106,18 @@ in
       example = lib.literalExpression ''[ /run/secrets/niks3-sign-key ]'';
     };
 
+    cacheUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "https://cache.example.com";
+      description = ''
+        Public URL where the binary cache is accessible.
+        This is used to generate a landing page (index.html) with usage instructions
+        and public keys, which is uploaded to the S3 bucket.
+        Also used for redirecting requests to the niks3 server root to the public cache.
+      '';
+    };
+
     user = lib.mkOption {
       type = lib.types.str;
       default = "niks3";
@@ -227,6 +239,10 @@ in
             --s3-access-key-path "${cfg.s3.accessKeyFile}" \
             --s3-secret-key-path "${cfg.s3.secretKeyFile}" \
             --api-token-path "${cfg.apiTokenFile}"${
+              lib.optionalString (cfg.cacheUrl != null) ''
+                \
+                            --cache-url "${cfg.cacheUrl}"''
+            }${
               lib.optionalString (cfg.signKeyFiles != [ ]) ''
                 \
                            ${lib.concatMapStringsSep " \\\n            " (

--- a/server/landing_page.go
+++ b/server/landing_page.go
@@ -1,0 +1,278 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+const landingPageTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nix Binary Cache</title>
+    <style>
+        :root {
+            --primary: #5277C3;
+            --bg: #ffffff;
+            --surface: #f5f5f5;
+            --text: #24292e;
+            --text-secondary: #586069;
+            --border: #e1e4e8;
+            --code-bg: #f6f8fa;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0d1117;
+                --surface: #161b22;
+                --text: #c9d1d9;
+                --text-secondary: #8b949e;
+                --border: #30363d;
+                --code-bg: #161b22;
+            }
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: var(--text);
+            background: var(--bg);
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            padding: 40px 0;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 10px;
+            color: var(--text);
+        }
+
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 1.1rem;
+        }
+
+        section {
+            margin: 40px 0;
+            padding: 30px;
+            background: var(--surface);
+            border-radius: 8px;
+            border: 1px solid var(--border);
+        }
+
+        h2 {
+            font-size: 1.5rem;
+            margin-bottom: 20px;
+            color: var(--text);
+        }
+
+        h3 {
+            font-size: 1.2rem;
+            margin: 25px 0 15px 0;
+            color: var(--text);
+        }
+
+        pre {
+            background: var(--code-bg);
+            padding: 16px;
+            border-radius: 6px;
+            overflow-x: auto;
+            border: 1px solid var(--border);
+            margin: 10px 0;
+        }
+
+        code {
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.9em;
+            color: var(--text);
+        }
+
+        .key-list {
+            margin: 15px 0;
+        }
+
+        .key-item {
+            background: var(--code-bg);
+            padding: 12px 16px;
+            border-radius: 6px;
+            margin: 10px 0;
+            border: 1px solid var(--border);
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+            font-size: 0.85em;
+            word-break: break-all;
+        }
+
+        .note {
+            background: rgba(255, 200, 61, 0.1);
+            border-left: 4px solid #ffc83d;
+            padding: 12px 16px;
+            margin: 15px 0;
+            border-radius: 4px;
+        }
+
+        .note p {
+            margin: 5px 0;
+            color: var(--text-secondary);
+        }
+
+        footer {
+            text-align: center;
+            padding: 40px 0;
+            color: var(--text-secondary);
+            border-top: 1px solid var(--border);
+            margin-top: 40px;
+        }
+
+        a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Nix Binary Cache</h1>
+            <p class="subtitle">Fast and reliable binary cache for Nix packages</p>
+        </header>
+
+        <section>
+            <h2>Public Keys</h2>
+            <p>Add these trusted public keys to your Nix configuration to verify packages from this cache:</p>
+
+            <div class="key-list">
+{{- range .PublicKeys }}
+                <div class="key-item">{{ . }}</div>
+{{- end }}
+{{- if eq (len .PublicKeys) 0 }}
+                <div class="note">
+                    <p>No signing keys are currently configured for this cache.</p>
+                </div>
+{{- end }}
+            </div>
+        </section>
+
+        <section>
+            <h2>Usage Instructions</h2>
+
+            <h3>Option 1: Command Line (Temporary)</h3>
+            <p>Use this cache for a single Nix command:</p>
+            <pre><code>nix build --substituters '{{ .CacheURL }}' \
+  --trusted-public-keys '{{ .PublicKeysJoined }}' \
+  nixpkgs#hello</code></pre>
+
+            <h3>Option 2: Nix Configuration (Persistent)</h3>
+            <p>Add to your <code>~/.config/nix/nix.conf</code> or <code>/etc/nix/nix.conf</code>:</p>
+            <pre><code>extra-substituters = {{ .CacheURL }}
+extra-trusted-public-keys = {{ .PublicKeysJoined }}</code></pre>
+
+            <h3>Option 3: NixOS Configuration</h3>
+            <p>Add to your <code>/etc/nixos/configuration.nix</code>:</p>
+            <pre><code>nix.settings = {
+  extra-substituters = [ "{{ .CacheURL }}" ];
+  extra-trusted-public-keys = [
+{{- range .PublicKeys }}
+    "{{ . }}"
+{{- end }}
+  ];
+};</code></pre>
+
+            <h3>Option 4: Flake</h3>
+            <p>Add to your <code>flake.nix</code>:</p>
+            <pre><code>{
+  nixConfig = {
+    extra-substituters = [ "{{ .CacheURL }}" ];
+    extra-trusted-public-keys = [
+{{- range .PublicKeys }}
+      "{{ . }}"
+{{- end }}
+    ];
+  };
+
+  # ... rest of your flake
+}</code></pre>
+
+            <div class="note">
+                <p><strong>Note:</strong> Using <code>extra-*</code> settings will add this cache alongside the default cache.nixos.org cache.</p>
+            </div>
+        </section>
+
+        <section>
+            <h2>Cache Information</h2>
+            <p>This binary cache is powered by <a href="https://github.com/Mic92/niks3" target="_blank">niks3</a>, a garbage-collected Nix binary cache backed by S3-compatible storage.</p>
+
+            <h3>Features</h3>
+            <ul style="margin-left: 20px; color: var(--text-secondary);">
+                <li>Cryptographically signed packages</li>
+                <li>Reference-tracking garbage collection</li>
+                <li>High availability via S3</li>
+                <li>Efficient storage with zstd compression</li>
+            </ul>
+        </section>
+
+        <footer>
+            <p>Powered by <a href="https://github.com/Mic92/niks3">niks3</a></p>
+        </footer>
+    </div>
+</body>
+</html>
+`
+
+type landingPageData struct {
+	PublicKeys       []string
+	PublicKeysJoined string
+	CacheURL         string
+}
+
+// GenerateLandingPage creates an HTML landing page with the cache's public keys and usage instructions.
+func (s *Service) GenerateLandingPage(cacheURL string) (string, error) {
+	publicKeys := make([]string, 0, len(s.SigningKeys))
+	for _, key := range s.SigningKeys {
+		pubKey, err := key.PublicKey()
+		if err != nil {
+			return "", fmt.Errorf("failed to get public key: %w", err)
+		}
+		publicKeys = append(publicKeys, pubKey)
+	}
+
+	data := landingPageData{
+		PublicKeys:       publicKeys,
+		PublicKeysJoined: strings.Join(publicKeys, " "),
+		CacheURL:         cacheURL,
+	}
+
+	tmpl, err := template.New("landing").Parse(landingPageTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/server/landing_page_test.go
+++ b/server/landing_page_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/server/signing"
+)
+
+func TestGenerateLandingPage(t *testing.T) {
+	// Create a test signing key
+	key, err := signing.ParseKey("test-cache:YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=")
+	if err != nil {
+		t.Fatalf("Failed to parse test key: %v", err)
+	}
+
+	service := &Service{
+		SigningKeys: []*signing.Key{key},
+		CacheURL:    "https://cache.example.com",
+	}
+
+	html, err := service.GenerateLandingPage("https://cache.example.com")
+	if err != nil {
+		t.Fatalf("Failed to generate landing page: %v", err)
+	}
+
+	// Verify the HTML contains expected elements
+	expectedStrings := []string{
+		"<!DOCTYPE html>",
+		"Nix Binary Cache",
+		"https://cache.example.com",
+		"test-cache:",
+		"extra-substituters",
+		"extra-trusted-public-keys",
+		"nixConfig",
+		"nix.settings",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(html, expected) {
+			t.Errorf("Landing page missing expected string: %q", expected)
+		}
+	}
+
+	// Verify it's valid HTML
+	if !strings.HasPrefix(html, "<!DOCTYPE html>") {
+		t.Error("Landing page does not start with DOCTYPE")
+	}
+
+	if !strings.Contains(html, "</html>") {
+		t.Error("Landing page does not end with closing html tag")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -68,6 +68,8 @@ func parseArgs() (*options, error) {
 		"Path to file containing S3 secret key")
 	flag.StringVar(&opts.APIToken, "api-token", getEnvOrDefault("NIKS3_API_TOKEN", ""), "API token for authentication")
 	flag.StringVar(&apiTokenPath, "api-token-path", getEnvOrDefault("NIKS3_API_TOKEN_PATH", ""), "API token file path")
+	flag.StringVar(&opts.CacheURL, "cache-url", getEnvOrDefault("NIKS3_CACHE_URL", ""),
+		"Public cache URL for the landing page (e.g., https://cache.example.com)")
 
 	// Parse signing key paths from environment variable (space-separated for backward compatibility)
 	signKeyPaths := (*stringSliceFlag)(&opts.SignKeyPaths)

--- a/server/redirect.go
+++ b/server/redirect.go
@@ -1,0 +1,25 @@
+package server
+
+import (
+	"net/http"
+)
+
+// RootRedirectHandler redirects requests to the root path to the public cache URL.
+func (s *Service) RootRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	// Only handle requests to the root path
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// If no cache URL is configured, return a simple message
+	if s.CacheURL == "" {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("niks3 binary cache server\n"))
+		return
+	}
+
+	// Redirect to the public cache URL
+	http.Redirect(w, r, s.CacheURL, http.StatusMovedPermanently)
+}

--- a/server/signing/key.go
+++ b/server/signing/key.go
@@ -84,3 +84,17 @@ func (k *Key) Sign(msg []byte) string {
 
 	return fmt.Sprintf("%s:%s", k.Name, signatureBase64)
 }
+
+// PublicKey returns the public key in the format "name:base64-public-key" for use in nix configuration.
+func (k *Key) PublicKey() (string, error) {
+	// Ed25519 public key is the last 32 bytes of the private key
+	publicKey, ok := k.key.Public().(ed25519.PublicKey)
+	if !ok {
+		// Type assertion failed - this should never happen with a properly initialized Ed25519 key
+		return "", fmt.Errorf("failed to extract Ed25519 public key from key %s", k.Name)
+	}
+
+	publicKeyBase64 := base64.StdEncoding.EncodeToString(publicKey)
+
+	return fmt.Sprintf("%s:%s", k.Name, publicKeyBase64), nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure a public cache URL via CLI flag or NIKS3_CACHE_URL env var
  * Server generates and serves a landing page showing public keys and cache info
  * Root path redirects to the configured cache URL when set

* **Documentation**
  * Added docs and example for the new cache URL option (commented example in README)

* **Tests**
  * Added tests verifying landing page output

* **Chores**
  * Updated linter configuration (added misspell ignore-words)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->