### PR TITLE
client: prevent double-wrapping in SetDebugHTTP

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -115,7 +115,10 @@ func (c *Client) SetDebugHTTP(enabled bool) {
 		if transport == nil {
 			transport = http.DefaultTransport
 		}
-		c.httpClient.Transport = &loggingTransport{transport: transport}
+		// Only wrap if not already wrapped
+		if _, ok := transport.(*loggingTransport); !ok {
+			c.httpClient.Transport = &loggingTransport{transport: transport}
+		}
 	} else {
 		// Unwrap if it's a logging transport
 		if lt, ok := c.httpClient.Transport.(*loggingTransport); ok {


### PR DESCRIPTION

Check if transport is already a loggingTransport before wrapping to avoid
nested wrappers that cause duplicate HTTP logs when SetDebugHTTP(true) is
called multiple times.
