### PR TITLE
pg: drop unused GIN index on objects.refs

### DIFF
--- a/server/pg/migrations/20251210153512_drop_unused_gin_index.sql
+++ b/server/pg/migrations/20251210153512_drop_unused_gin_index.sql
@@ -1,0 +1,10 @@
+-- The GIN index on refs was never used by any query.
+-- All recursive CTE queries use `o.key = ANY(cr.refs)` which uses the PK index on objects.key,
+-- not the GIN index on refs. The GIN index only helps with `refs @> ARRAY[...]` queries
+-- which don't exist in the codebase.
+
+-- +goose Up
+DROP INDEX IF EXISTS objects_refs_gin;
+
+-- +goose Down
+CREATE INDEX objects_refs_gin ON objects USING gin (refs);


### PR DESCRIPTION

The GIN index was never used by any query. All recursive CTE queries
use `o.key = ANY(cr.refs)` which leverages the PK index on objects.key.
The GIN index would only help with `refs @> ARRAY[...]` pattern queries
(finding objects that reference a given key), which don't exist.

Removing this index reduces storage overhead and speeds up INSERTs.
