### PR TITLE
nix: wrap niks3 client with stable Nix in PATH

### DIFF
--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -10,6 +10,7 @@
       packages.rustfs = pkgs.callPackage ./rustfs.nix { };
       packages.niks3 = pkgs.callPackage ./niks3.nix {
         inherit (pkgs) go;
+        nix = pkgs.nixVersions.stable;
       };
       packages.niks3-docker = pkgs.callPackage ./niks3-docker.nix {
         inherit (config.packages) niks3;

--- a/nix/packages/niks3.nix
+++ b/nix/packages/niks3.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   go,
+  nix,
 }:
 
 let
@@ -31,6 +32,8 @@ pkgs.buildGoModule {
 
   doCheck = false;
 
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
   # Add unittest output for pre-compiled test binaries
   outputs = [
     "out"
@@ -55,6 +58,15 @@ pkgs.buildGoModule {
       for f in $unittest/bin/*.test; do
         remove-references-to -t ${go} "$f"
       done
+    fi
+
+    # Wrap niks3 client to include nix in PATH
+    # This avoids compatibility issues with Lix's different `nix path-info --json` output
+    # See: https://github.com/Mic92/niks3/issues/181
+    # Skip wrapping in cross-compilation (binary is in a subdirectory)
+    if [ -f $out/bin/niks3 ]; then
+      wrapProgram $out/bin/niks3 \
+        --prefix PATH : ${lib.makeBinPath [ nix ]}
     fi
   '';
 }


### PR DESCRIPTION

Wrap the niks3 client binary to include nixVersions.stable in PATH,
ensuring consistent behavior regardless of what nix versions has been
installed.

fixes: https://github.com/Mic92/niks3/issues/181
