### PR TITLE
Revert "bump version 1.2.0"

### DIFF
--- a/nix/packages/niks3.nix
+++ b/nix/packages/niks3.nix
@@ -10,7 +10,7 @@ let
 in
 pkgs.buildGoModule {
   pname = "niks3";
-  version = "1.2.0";
+  version = "1.1.1";
   src = lib.fileset.toSource {
     fileset = lib.fileset.unions [
       ../../api


### PR DESCRIPTION

This reverts commit 7c99d98fa0f801c2a8e57c3c7a7bdc69a036c52a.

Easier to trigger another release
