### PR TITLE
server: return 429 with Retry-After header on S3 rate limit errors

### DIFF
--- a/server/s3_rate_limiter.go
+++ b/server/s3_rate_limiter.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"sync"
@@ -150,14 +151,44 @@ func (a *AdaptiveRateLimiter) CurrentRate() float64 {
 	return a.currentRate
 }
 
-// isRateLimitError checks if a minio error is a rate limit/throttle response.
-// S3 uses 503 with "SlowDown" error code, not 429. Some S3-compatible
-// providers may use 429 or other codes.
-func isRateLimitError(err error) bool {
+// handleS3Error checks if an error is a rate limit and returns appropriate HTTP response.
+// Returns true if the error was handled (caller should return), false if caller should
+// handle the error itself. It checks the error message for rate limit indicators since
+// errors may be wrapped as they bubble up through the call stack.
+func (s *Service) handleS3Error(w http.ResponseWriter, err error, operation string) bool {
 	if err == nil {
 		return false
 	}
 
+	// Check if any error in the chain is a rate limit error
+	if isRateLimitError(err) {
+		slog.Warn("S3 rate limit hit", "operation", operation, "error", err)
+		w.Header().Set("Retry-After", "2")
+		http.Error(w, "S3 rate limit exceeded, please retry", http.StatusTooManyRequests)
+
+		return true
+	}
+
+	return false
+}
+
+// isRateLimitError checks if a minio error (or any error in a wrapped chain)
+// is a rate limit/throttle response. S3 uses 503 with "SlowDown" error code.
+// Some S3-compatible providers may use 429 or other codes.
+func isRateLimitError(err error) bool {
+	for err != nil {
+		if isMinioRateLimitError(err) {
+			return true
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	return false
+}
+
+// isMinioRateLimitError checks a single error (not unwrapped) for rate limit indicators.
+func isMinioRateLimitError(err error) bool {
 	errResp := minio.ToErrorResponse(err)
 
 	// Check S3 error codes (primary detection method)


### PR DESCRIPTION
When S3 returns a rate limit error (SlowDown, 429, or Backblaze B2's 'too many requests' message), return HTTP 429 to the client with a Retry-After: 1 header instead of 500 Internal Server Error.

This allows clients to distinguish rate limit errors from actual failures and retry appropriately. The client already handles 429 responses and honors the Retry-After header.