### PR TITLE
docker: use regctl to push multi-arch images to ghcr.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,24 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Docker Setup Docker
-        uses: docker/setup-docker-action@v4
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Create Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -59,12 +41,15 @@ jobs:
         run: |
           nix build .#niks3-docker --print-build-logs
       - name: Push images
+        env:
+          REGCTL_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -xve
-          image_tag=$(docker load < ./result | grep "Loaded image" | awk '{print $3}')
+          PATH="$(nix build --inputs-from . nixpkgs#regctl --print-out-paths --no-link)/bin:$PATH"
+          regctl registry login "$REGISTRY" -u "${{ github.actor }}" --pass-stdin <<< "$REGCTL_PASSWORD"
+          regctl image import "ocidir://local:niks3" ./result
           for tag in $(echo '${{ steps.meta.outputs.tags }}' | tr ' ' '\n'); do
-            docker tag "$image_tag" "$tag"
-            docker push "$tag"
+            regctl image copy "ocidir://local:niks3" "$tag"
           done
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous workflow used docker load/tag/push with containerd snapshotter enabled, which created an OCI image index but failed to push the child platform manifests. This resulted in a registry that returned MANIFEST_UNKNOWN when clients tried to pull, as the index referenced digests that didn't exist.

Switch to regctl for the entire push flow since the Nix build already produces a regctl-exported tar archive. regctl correctly pushes all manifests (index + platform manifests + blobs) to the registry.

Closes #229