### PR TITLE
Lix path info support

### DIFF
--- a/client/export_test.go
+++ b/client/export_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/Mic92/niks3/ratelimit"
 )
 
+// ParsePathInfoJSON exports parsePathInfoJSON for testing.
+var ParsePathInfoJSON = parsePathInfoJSON
+
 // NewTestClient creates a Client for testing with a custom HTTP client and retry config.
 func NewTestClient(httpClient *http.Client, retry RetryConfig) *Client {
 	return &Client{

--- a/client/nixstore_test.go
+++ b/client/nixstore_test.go
@@ -117,6 +117,165 @@ func TestPathInfoHashCompatibility(t *testing.T) {
 	}
 }
 
+func TestParsePathInfoJSON(t *testing.T) {
+	t.Parallel()
+
+	nixJSON := `{
+		"/nix/store/8ha1dhmx807czjczmwy078s4r9s254il-hello-2.12.2": {
+			"narHash": "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=",
+			"narSize": 226560,
+			"references": [
+				"/nix/store/3n58xw4373jp0ljirf06d8077j15pc4j-glibc-2.37-8",
+				"/nix/store/8ha1dhmx807czjczmwy078s4r9s254il-hello-2.12.2"
+			],
+			"deriver": "/nix/store/abc-hello.drv",
+			"signatures": ["cache.nixos.org-1:sig"]
+		}
+	}`
+
+	lixJSON := `[
+		{
+			"path": "/nix/store/8ha1dhmx807czjczmwy078s4r9s254il-hello-2.12.2",
+			"narHash": "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=",
+			"narSize": 226560,
+			"references": [
+				"/nix/store/3n58xw4373jp0ljirf06d8077j15pc4j-glibc-2.37-8",
+				"/nix/store/8ha1dhmx807czjczmwy078s4r9s254il-hello-2.12.2"
+			],
+			"deriver": "/nix/store/abc-hello.drv",
+			"signatures": ["cache.nixos.org-1:sig"]
+		}
+	]`
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "Nix format", input: nixJSON, wantErr: false},
+		{name: "Lix format", input: lixJSON, wantErr: false},
+		{name: "empty input", input: "", wantErr: true},
+		{name: "whitespace only", input: "   \n\t  ", wantErr: true},
+		{name: "invalid JSON", input: "not json", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := client.ParsePathInfoJSON([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParsePathInfoJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			storePath := "/nix/store/8ha1dhmx807czjczmwy078s4r9s254il-hello-2.12.2"
+
+			info, ok := result[storePath]
+			if !ok {
+				t.Fatalf("expected key %q in result, got keys: %v", storePath, keys(result))
+			}
+
+			if info.Path != storePath {
+				t.Errorf("Path = %q, want %q", info.Path, storePath)
+			}
+
+			if info.NarHash.String() != "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=" {
+				t.Errorf("NarHash = %q, want %q", info.NarHash.String(), "sha256-FePFYIlMuycIXPZbWi7LGEiMmZSX9FMbaQenWBzm1Sc=")
+			}
+
+			if info.NarSize != 226560 {
+				t.Errorf("NarSize = %d, want %d", info.NarSize, 226560)
+			}
+
+			if len(info.References) != 2 {
+				t.Errorf("References count = %d, want %d", len(info.References), 2)
+			}
+
+			if info.Deriver == nil || *info.Deriver != "/nix/store/abc-hello.drv" {
+				t.Errorf("Deriver = %v, want %q", info.Deriver, "/nix/store/abc-hello.drv")
+			}
+
+			if len(info.Signatures) != 1 || info.Signatures[0] != "cache.nixos.org-1:sig" {
+				t.Errorf("Signatures = %v, want %v", info.Signatures, []string{"cache.nixos.org-1:sig"})
+			}
+		})
+	}
+}
+
+func keys(m map[string]*client.PathInfo) []string {
+	result := make([]string, 0, len(m))
+	for k := range m {
+		result = append(result, k)
+	}
+
+	return result
+}
+
+func TestParsePathInfoJSONMultiplePaths(t *testing.T) {
+	t.Parallel()
+
+	nixJSON := `{
+		"/nix/store/aaaa-foo": {"narHash": "sha256-abc=", "narSize": 100, "references": []},
+		"/nix/store/bbbb-bar": {"narHash": "sha256-def=", "narSize": 200, "references": []}
+	}`
+
+	lixJSON := `[
+		{"path": "/nix/store/aaaa-foo", "narHash": "sha256-abc=", "narSize": 100, "references": []},
+		{"path": "/nix/store/bbbb-bar", "narHash": "sha256-def=", "narSize": 200, "references": []}
+	]`
+
+	for _, tt := range []struct {
+		name  string
+		input string
+	}{
+		{name: "Nix multiple paths", input: nixJSON},
+		{name: "Lix multiple paths", input: lixJSON},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := client.ParsePathInfoJSON([]byte(tt.input))
+			if err != nil {
+				t.Fatalf("ParsePathInfoJSON() error = %v", err)
+			}
+
+			if len(result) != 2 {
+				t.Fatalf("expected 2 entries, got %d", len(result))
+			}
+
+			foo := result["/nix/store/aaaa-foo"]
+			if foo == nil {
+				t.Fatal("missing /nix/store/aaaa-foo")
+			}
+
+			if foo.Path != "/nix/store/aaaa-foo" {
+				t.Errorf("foo.Path = %q, want %q", foo.Path, "/nix/store/aaaa-foo")
+			}
+
+			if foo.NarSize != 100 {
+				t.Errorf("foo.NarSize = %d, want 100", foo.NarSize)
+			}
+
+			bar := result["/nix/store/bbbb-bar"]
+			if bar == nil {
+				t.Fatal("missing /nix/store/bbbb-bar")
+			}
+
+			if bar.Path != "/nix/store/bbbb-bar" {
+				t.Errorf("bar.Path = %q, want %q", bar.Path, "/nix/store/bbbb-bar")
+			}
+
+			if bar.NarSize != 200 {
+				t.Errorf("bar.NarSize = %d, want 200", bar.NarSize)
+			}
+		})
+	}
+}
+
 func TestPathInfoCACompatibility(t *testing.T) {
 	t.Parallel()
 

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -66,6 +66,15 @@
             mock-oidc-server = config.packages.mock-oidc-server;
             niks3 = config.packages.niks3;
             rustfs = config.packages.rustfs;
+            nix = pkgs.nixVersions.latest;
+            ca-derivations-supported = true;
+          };
+          nixos-test-niks3-lix = pkgs.callPackage ./nixos-test-niks3.nix {
+            mock-oidc-server = config.packages.mock-oidc-server;
+            niks3 = config.packages.niks3;
+            rustfs = config.packages.rustfs;
+            nix = pkgs.lixPackageSets.latest.lix;
+            ca-derivations-supported = false;
           };
           nixos-test-read-proxy = pkgs.callPackage ./nixos-test-read-proxy.nix {
             niks3 = config.packages.niks3;

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -10,7 +10,6 @@
       packages.rustfs = pkgs.callPackage ./rustfs.nix { };
       packages.niks3 = pkgs.callPackage ./niks3.nix {
         inherit (pkgs) go;
-        nix = pkgs.nixVersions.stable;
       };
       packages.niks3-docker = pkgs.callPackage ./niks3-docker.nix {
         inherit (config.packages) niks3;

--- a/nix/packages/niks3.nix
+++ b/nix/packages/niks3.nix
@@ -2,7 +2,6 @@
   pkgs,
   lib,
   go,
-  nix,
 }:
 
 let
@@ -33,8 +32,6 @@ pkgs.buildGoModule {
 
   doCheck = false;
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
-
   # Add unittest output for pre-compiled test binaries
   outputs = [
     "out"
@@ -59,15 +56,6 @@ pkgs.buildGoModule {
       for f in $unittest/bin/*.test; do
         remove-references-to -t ${go} "$f"
       done
-    fi
-
-    # Wrap niks3 client to include nix in PATH
-    # This avoids compatibility issues with Lix's different `nix path-info --json` output
-    # See: https://github.com/Mic92/niks3/issues/181
-    # Skip wrapping in cross-compilation (binary is in a subdirectory)
-    if [ -f $out/bin/niks3 ]; then
-      wrapProgram $out/bin/niks3 \
-        --prefix PATH : ${lib.makeBinPath [ nix ]}
     fi
   '';
 }


### PR DESCRIPTION
For work, we're running Lix as our Nix. #181 obviously is an issue. So I implemented a quick fix with the help of my co-worker Claude that I think is correct to both deal with Nix and Lix `nix path-info --json` outputs, since they're not likely to converge. I don't think it came out too badly. Let me know what you think.