### PR TITLE
feat: support IAM-based S3 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ niks3 implements the [Nix binary cache specification](https://nixos.org/manual/n
 
 - Authentication via API tokens (Bearer auth)
 - OIDC authentication for CI/CD systems (GitHub Actions, GitLab CI)
+- S3 credentials via static keys (`--s3-access-key` / `--s3-secret-key`) or IAM (`--s3-use-iam` for IRSA, EC2 instance profiles, ECS task roles)
 
 ## Choosing an S3 Provider
 

--- a/server/server.go
+++ b/server/server.go
@@ -24,11 +24,11 @@ type options struct {
 	DBConnectionString string
 	HTTPAddr           string
 
-	// TODO: Document how to use this with AWS.
 	S3Endpoint    string
 	S3AccessKey   string
 	S3SecretKey   string
 	S3UseSSL      bool
+	S3UseIAM      bool
 	S3Bucket      string
 	S3Concurrency int
 	S3RateLimit   float64
@@ -162,8 +162,15 @@ func runServer(opts *options) error {
 	}
 	defer pool.Close()
 
+	var creds *credentials.Credentials
+	if opts.S3UseIAM {
+		creds = credentials.NewIAM("")
+	} else {
+		creds = credentials.NewStaticV4(opts.S3AccessKey, opts.S3SecretKey, "")
+	}
+
 	minioClient, err := minio.New(opts.S3Endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(opts.S3AccessKey, opts.S3SecretKey, ""),
+		Creds:  creds,
 		Secure: opts.S3UseSSL,
 	})
 	if err != nil {


### PR DESCRIPTION
The `minio` SDK already supports IAM-based credentials. Enabling that behavior triggers the full "credential chain" logic:

- AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
- A credentials file at ~/.aws/credentials
- AWS config file at ~/.aws/config
- AWS identity tokens
- ECS container credentials
- EC2 instance metadata

This patch adds a `--s3-use-iam` flag which is mutually exclusive with the static or file-based credential flags. With this flag turned on, most deployments of niks3 into AWS should be able to authenticate automatically.