### PR TITLE
s3: add region override option

### DIFF
--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -134,6 +134,19 @@ in
         description = "S3 bucket name.";
       };
 
+      region = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = ''
+          S3 region override. When set, this region is used for request signing
+          instead of auto-detecting from the endpoint URL.
+          Required for some S3-compatible providers (e.g., "auto" for Cloudflare R2,
+          "eu-central-003" for Backblaze B2).
+          If empty, the region is inferred from the endpoint URL, defaulting to "us-east-1".
+        '';
+        example = "us-east-1";
+      };
+
       useSSL = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -390,7 +403,11 @@ in
             --http-addr "${cfg.httpAddr}" \
             --s3-endpoint "${cfg.s3.endpoint}" \
             --s3-bucket "${cfg.s3.bucket}" \
-            --s3-use-ssl="${if cfg.s3.useSSL then "true" else "false"}" \
+            --s3-use-ssl="${if cfg.s3.useSSL then "true" else "false"}"${
+              lib.optionalString (cfg.s3.region != "") ''
+                \
+                           --s3-region "${cfg.s3.region}"''
+            } \
             ${
               if cfg.s3.useIAM then
                 "--s3-use-iam"

--- a/server/main.go
+++ b/server/main.go
@@ -86,6 +86,7 @@ func parseArgs() (*options, error) {
 	flag.BoolVar(&opts.S3UseIAM, "s3-use-iam", getEnvOrDefault("NIKS3_S3_USE_IAM", "false") == "true",
 		"Use IAM credentials from the environment (IRSA, EC2 instance profile, etc.) instead of static keys")
 	flag.StringVar(&opts.S3Bucket, "s3-bucket", getEnvOrDefault("NIKS3_S3_BUCKET", ""), "S3 bucket name")
+	flag.StringVar(&opts.S3Region, "s3-region", getEnvOrDefault("NIKS3_S3_REGION", ""), "S3 region override (e.g., us-east-1, auto)")
 	flag.StringVar(&s3AccessKeyPath, "s3-access-key-path", getEnvOrDefault("NIKS3_S3_ACCESS_KEY_PATH", ""),
 		"Path to file containing S3 access key")
 	flag.StringVar(&s3SecretKeyPath, "s3-secret-key-path", getEnvOrDefault("NIKS3_S3_SECRET_KEY_PATH", ""),

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ type options struct {
 	S3UseSSL      bool
 	S3UseIAM      bool
 	S3Bucket      string
+	S3Region      string
 	S3Concurrency int
 	S3RateLimit   float64
 
@@ -172,6 +173,7 @@ func runServer(opts *options) error {
 	minioClient, err := minio.New(opts.S3Endpoint, &minio.Options{
 		Creds:  creds,
 		Secure: opts.S3UseSSL,
+		Region: opts.S3Region,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create minio s3 client: %w", err)


### PR DESCRIPTION
Some S3-compatible providers (Cloudflare R2, Backblaze B2) need an
explicit region for request signing that cannot be inferred from the
endpoint URL. Without this, minio-go falls back to us-east-1 which
may not match what the provider expects.

Add `--s3-region` flag / `NIKS3_S3_REGION` env var to the server and
`services.niks3.s3.region` to the NixOS module. When empty (default),
the existing auto-detection behavior is preserved.

Closes #259