### PR TITLE
niks3-docker: embed niks3 binary in docker image

### DIFF
--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -39,6 +39,7 @@ let
             fi
           '';
         }))
+        (import ./niks3.nix { inherit pkgs lib; })
       ]
       ++ (with crossPkgs.pkgsStatic; [
         busybox


### PR DESCRIPTION
Adds `niks3` binary in Docker image.

Testing process:

```bash
❯ nix build .#niks3-docker

❯ skopeo copy \
  --dest-daemon-host "unix://$XDG_RUNTIME_DIR/docker.sock" \
  oci-archive:result \
  docker-daemon:niks3:latest
Getting image source signatures
Copying blob 4c37e6325f8b done   | 
[...]
Writing manifest to image destination

❯ docker run -it --entrypoint /bin/niks3 niks3:latest
Usage: niks3 <command> [flags]

Commands:
  push    Upload paths to S3-compatible binary cache
  gc      Run garbage collection on old closures

Global flags:
  -h, --help    Show help

Use 'niks3 <command> --help' for more information about a command.
2026/04/11 14:33:13 ERROR Fatal error error="no command provided"
```

Solves #333.

Used successfully in my [homelab](https://github.com/cterence/homelab-gitops/blob/1b06bd64c5fc88ead5306e8b929070e4dcf98287/k8s-apps/niks3/values.yaml#L78-L102).