### PR TITLE
server: validate object keys on upload paths

### DIFF
--- a/server/multipart_cleanup_test.go
+++ b/server/multipart_cleanup_test.go
@@ -20,9 +20,9 @@ func TestMultipartCleanup(t *testing.T) {
 	defer service.Close()
 
 	// Create a pending closure with multipart upload
-	closureHash := "deadbeefdeadbeefdeadbeefdeadbeef"
+	closureHash := "dadb44fdadb44fdadb44fdadb44f0000"
 	closureKey := closureHash + ".narinfo"
-	narKey := "nar/" + closureHash + ".nar.zst"
+	narKey := narKeyFor(closureHash)
 
 	// Use a large NarSize to ensure multipart upload is used
 	largeNarSize := uint64(100 * 1024 * 1024) // 100MB

--- a/server/request_test.go
+++ b/server/request_test.go
@@ -162,6 +162,13 @@ func nixStoreAdd(tb testing.TB, nixEnv []string, filePath string) string {
 	return strings.TrimSpace(string(output))
 }
 
+// narKeyFor returns a syntactically valid NAR object key for tests.
+// Real NAR keys use a 52-char nix-base32 sha256 hash; we pad the 32-char
+// closure hash with a fixed nix-base32 suffix so IsValidUploadKey accepts it.
+func narKeyFor(closureHash string) string {
+	return "nar/" + closureHash + "00000000000000000000.nar.zst"
+}
+
 type TestRequest struct {
 	method  string
 	path    string

--- a/server/throttle_test.go
+++ b/server/throttle_test.go
@@ -120,7 +120,7 @@ func TestCompleteMultipartUploadHandler_RateLimitTriggersThrottle(t *testing.T) 
 	// Step 1: Create a pending closure to get multipart upload info
 	closureHash := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01"
 	narinfoKey := closureHash + ".narinfo"
-	narKey := "nar/" + closureHash + ".nar.zst"
+	narKey := narKeyFor(closureHash)
 
 	body, err := json.Marshal(map[string]any{
 		"closure": narinfoKey,

--- a/server/upload_key.go
+++ b/server/upload_key.go
@@ -1,0 +1,37 @@
+package server
+
+import "strings"
+
+// IsValidUploadKey reports whether a client may request a presigned upload
+// for the given object key and declared type.
+//
+// This is the write-side counterpart of IsValidCachePath. It is stricter:
+// the key must match the exact pattern for its declared type, and
+// server-owned files (nix-cache-info, index.html) are never client-writable.
+// Without this check an authenticated client could obtain presigned PUT URLs
+// for arbitrary S3 keys — overwriting nix-cache-info, hosting attacker HTML
+// under the cache origin, or poisoning unrelated objects.
+func IsValidUploadKey(key, objType string) bool {
+	if key == "" {
+		return false
+	}
+
+	if strings.HasPrefix(key, "/") || strings.Contains(key, "..") {
+		return false
+	}
+
+	switch objType {
+	case "narinfo":
+		return narinfoRe.MatchString(key)
+	case "nar":
+		return narRe.MatchString(key)
+	case "listing":
+		return lsRe.MatchString(key)
+	case "build_log":
+		return logRe.MatchString(key)
+	case "realisation":
+		return realisationsRe.MatchString(key)
+	default:
+		return false
+	}
+}

--- a/server/upload_key_test.go
+++ b/server/upload_key_test.go
@@ -1,0 +1,137 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/server"
+)
+
+func TestIsValidUploadKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		objType string
+		valid   bool
+	}{
+		// Valid uploads
+		{"narinfo", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", "narinfo", true},
+		{"nar zst", "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar.zst", "nar", true},
+		{"nar xz", "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar.xz", "nar", true},
+		{"nar plain", "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar", "nar", true},
+		{"listing", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.ls", "listing", true},
+		{"build log", "log/abcd1234-hello-1.0.drv", "build_log", true},
+		{"realisation", "realisations/sha256:abc123!out.doi", "realisation", true},
+
+		// Server-owned files: never client-writable
+		{"nix-cache-info", "nix-cache-info", "narinfo", false},
+		{"index.html", "index.html", "narinfo", false},
+
+		// Type/key mismatch
+		{"narinfo key, nar type", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", "nar", false},
+		{"nar key, narinfo type", "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar.zst", "narinfo", false},
+		{"listing key, narinfo type", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.ls", "narinfo", false},
+
+		// Path traversal / arbitrary keys
+		{"traversal", "../etc/passwd", "narinfo", false},
+		{"traversal nar", "nar/../../secrets", "nar", false},
+		{"absolute", "/26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", "narinfo", false},
+		{"empty key", "", "narinfo", false},
+		{"unknown type", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", "weird", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := server.IsValidUploadKey(tc.key, tc.objType)
+			if got != tc.valid {
+				t.Errorf("IsValidUploadKey(%q, %q) = %v, want %v", tc.key, tc.objType, got, tc.valid)
+			}
+		})
+	}
+}
+
+// TestUploadHandlersRejectInvalidKeys ensures handlers actually enforce
+// IsValidUploadKey and reject malicious keys before touching DB or S3.
+// Validation runs on the request body alone, so a zero-value Service suffices.
+func TestUploadHandlersRejectInvalidKeys(t *testing.T) {
+	t.Parallel()
+
+	svc := &server.Service{}
+
+	post := func(t *testing.T, h http.HandlerFunc, body any) *httptest.ResponseRecorder {
+		t.Helper()
+
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(string(data)))
+		h.ServeHTTP(rr, req)
+
+		return rr
+	}
+
+	t.Run("create pending closure rejects nix-cache-info", func(t *testing.T) {
+		t.Parallel()
+
+		rr := post(t, svc.CreatePendingClosureHandler, map[string]any{
+			"closure": "00000000000000000000000000000000.narinfo",
+			"objects": []map[string]any{
+				{"key": "nix-cache-info", "type": "narinfo", "refs": []string{}},
+			},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("create pending closure rejects path traversal", func(t *testing.T) {
+		t.Parallel()
+
+		rr := post(t, svc.CreatePendingClosureHandler, map[string]any{
+			"closure": "00000000000000000000000000000000.narinfo",
+			"objects": []map[string]any{
+				{"key": "nar/../../../etc/passwd", "type": "nar", "refs": []string{}},
+			},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("complete multipart rejects non-NAR key", func(t *testing.T) {
+		t.Parallel()
+
+		rr := post(t, svc.CompleteMultipartUploadHandler, map[string]any{
+			"object_key": "nix-cache-info",
+			"upload_id":  "x",
+			"parts":      []map[string]any{{"part_number": 1, "etag": "a"}},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("request more parts rejects non-NAR key", func(t *testing.T) {
+		t.Parallel()
+
+		rr := post(t, svc.RequestMorePartsHandler, map[string]any{
+			"object_key":        "index.html",
+			"upload_id":         "x",
+			"start_part_number": 1,
+			"num_parts":         1,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -85,7 +85,15 @@ func (s *Service) CreatePendingClosureHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	objectsMap := make(map[string]objectWithRefs)
+
 	for _, object := range req.Objects {
+		// Security gate: must run before any DB or S3 work.
+		if !IsValidUploadKey(object.Key, object.Type) {
+			http.Error(w, fmt.Sprintf("invalid object key %q for type %q", object.Key, object.Type), http.StatusBadRequest)
+
+			return
+		}
+
 		objectsMap[object.Key] = object
 	}
 
@@ -153,6 +161,13 @@ func (s *Service) RequestMorePartsHandler(w http.ResponseWriter, r *http.Request
 
 	if req.ObjectKey == "" {
 		http.Error(w, "missing object_key", http.StatusBadRequest)
+
+		return
+	}
+
+	// Multipart uploads are only ever created for NAR objects.
+	if !IsValidUploadKey(req.ObjectKey, "nar") {
+		http.Error(w, fmt.Sprintf("invalid object key %q", req.ObjectKey), http.StatusBadRequest)
 
 		return
 	}
@@ -255,6 +270,13 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 
 	if req.ObjectKey == "" {
 		http.Error(w, "missing object_key", http.StatusBadRequest)
+
+		return
+	}
+
+	// Multipart uploads are only ever created for NAR objects.
+	if !IsValidUploadKey(req.ObjectKey, "nar") {
+		http.Error(w, fmt.Sprintf("invalid object key %q", req.ObjectKey), http.StatusBadRequest)
 
 		return
 	}

--- a/server/uploads_test.go
+++ b/server/uploads_test.go
@@ -45,7 +45,7 @@ func TestService_cleanupPendingClosuresHandler(t *testing.T) {
 
 	closureHash := "00000000000000000000000000000000"
 	closureKey := closureHash + ".narinfo"
-	narKey := "nar/" + closureHash + ".nar.zst"
+	narKey := narKeyFor(closureHash)
 	objects := []map[string]any{
 		{"key": closureKey, "type": "narinfo", "refs": []string{narKey}},
 		{"key": narKey, "type": "nar", "refs": []string{}},
@@ -207,7 +207,7 @@ func TestService_createPendingClosureHandler(t *testing.T) {
 	checkBareClosure := checkStatusCode(http.StatusBadRequest)
 	closureHash := "ffffffffffffffffffffffffffffffff"
 	narinfoKey := closureHash + ".narinfo"
-	narKey := "nar/" + closureHash + ".nar.zst"
+	narKey := narKeyFor(closureHash)
 
 	bodyBareClosure, err := json.Marshal(map[string]any{
 		"closure": closureHash,
@@ -227,8 +227,8 @@ func TestService_createPendingClosureHandler(t *testing.T) {
 	})
 
 	closureKey := "00000000000000000000000000000000"
-	firstObject := closureKey + ".narinfo"           // This should be the narinfo file
-	secondObject := "nar/" + closureKey + ".nar.zst" // This should be the NAR file
+	firstObject := closureKey + ".narinfo" // This should be the narinfo file
+	secondObject := narKeyFor(closureKey)  // This should be the NAR file
 	objects := []map[string]any{
 		{"key": firstObject, "type": "narinfo", "refs": []string{secondObject}}, // narinfo references the NAR file
 		{"key": secondObject, "type": "nar", "refs": []string{}},                // NAR file has no references
@@ -268,7 +268,7 @@ func TestService_createPendingClosureHandler(t *testing.T) {
 			// Narinfo is handled server-side - collect metadata instead
 			narinfoMetadata[key] = map[string]any{
 				"store_path":  "/nix/store/" + closureKey + "-test-package",
-				"url":         "nar/" + closureKey + ".nar.zst",
+				"url":         narKeyFor(closureKey),
 				"compression": "zstd",
 				"nar_hash":    "sha256:0000000000000000000000000000000000000000000000000000",
 				"nar_size":    1000,
@@ -387,9 +387,9 @@ func TestService_verifyS3Integrity(t *testing.T) {
 	defer service.Close()
 
 	// Step 1: Upload a closure
-	closureKey := "deadbeefdeadbeefdeadbeefdeadbeef"
+	closureKey := "dadb44fdadb44fdadb44fdadb44f0000"
 	narinfoKey := closureKey + ".narinfo"
-	narKey := "nar/" + closureKey + ".nar.zst"
+	narKey := narKeyFor(closureKey)
 	objects := []map[string]any{
 		{"key": narinfoKey, "type": "narinfo", "refs": []string{narKey}},
 		{"key": narKey, "type": "nar", "refs": []string{}},


### PR DESCRIPTION

Authenticated clients could request presigned PUT URLs for arbitrary S3
keys: the read proxy allowlists paths via IsValidCachePath, but the
write side accepted any key verbatim. A client with a valid token (or an
overly-broad OIDC bound claim) could overwrite server-owned objects like
nix-cache-info or index.html, or write outside the expected key layout.
With the read proxy enabled, an attacker-controlled index.html is served
under the cache origin.

Add IsValidUploadKey and enforce it in all three upload handlers before
any DB or S3 work. Keys must match the exact pattern for their declared
type; server-owned files are never client-writable. Multipart handlers
always require NAR keys since multipart is only used for NARs.

Also fix test fixtures to use syntactically valid nix-base32 hashes.
