### PR TITLE
feat(server): add /api/cache-config endpoint

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -64,3 +64,20 @@ type GCConflictResponse struct {
 	Error      string       `json:"error"`
 	ActiveTask GCTaskStatus `json:"active_task"`
 }
+
+// CacheConfig is returned by GET /api/cache-config and tells CI integrations
+// how to configure Nix (substituter, trusted keys) and which OIDC audience
+// to request when fetching a token.
+type CacheConfig struct {
+	// SubstituterURL is the read path clients should add to extra-substituters.
+	// Empty if the server was not started with --cache-url.
+	SubstituterURL string `json:"substituter_url"`
+
+	// PublicKeys lists the cache's signing keys in nix.conf format ("name:base64").
+	PublicKeys []string `json:"public_keys"`
+
+	// OIDCAudience is the audience to request when fetching an OIDC token for
+	// the issuer passed via ?issuer=. Empty if no issuer was requested or no
+	// matching provider is configured.
+	OIDCAudience string `json:"oidc_audience,omitempty"`
+}

--- a/hook/worker.go
+++ b/hook/worker.go
@@ -203,11 +203,9 @@ func (w *Worker) drain() {
 			continue
 		}
 
-		drainCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		uploaded, err := w.push(drainCtx, existing)
-
-		cancel()
-
+		// No timeout: the supervisor (systemd / CI post step) enforces the
+		// shutdown budget and SIGKILLs on expiry.
+		uploaded, err := w.push(context.Background(), existing)
 		if err != nil {
 			slog.Error("Drain upload failed, paths remain in queue for next start", "error", err, "count", len(existing))
 

--- a/server/cache_config.go
+++ b/server/cache_config.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/Mic92/niks3/api"
+)
+
+// CacheConfigHandler handles GET /api/cache-config.
+//
+// Unauthenticated — everything returned is already public (the landing page
+// shows the same keys). This lets CI integrations auto-configure substituters
+// and OIDC audience without users hardcoding them in workflow YAML.
+//
+// Query param ?issuer=<url> selects which OIDC provider's audience to return.
+// An unknown issuer is not an error: oidc_audience is simply omitted and the
+// caller must supply the audience itself (or the server has no OIDC for that CI).
+func (s *Service) CacheConfigHandler(w http.ResponseWriter, r *http.Request) {
+	cfg := api.CacheConfig{
+		SubstituterURL: s.CacheURL,
+		PublicKeys:     make([]string, 0, len(s.SigningKeys)),
+	}
+
+	for _, key := range s.SigningKeys {
+		pub, err := key.PublicKey()
+		if err != nil {
+			slog.Error("failed to derive public key", "error", err)
+			http.Error(w, "failed to derive public key", http.StatusInternalServerError)
+
+			return
+		}
+
+		cfg.PublicKeys = append(cfg.PublicKeys, pub)
+	}
+
+	if issuer := r.URL.Query().Get("issuer"); issuer != "" && s.OIDCValidator != nil {
+		if aud, ok := s.OIDCValidator.AudienceForIssuer(issuer); ok {
+			cfg.OIDCAudience = aud
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(cfg); err != nil {
+		slog.Error("failed to encode cache-config response", "error", err)
+	}
+}

--- a/server/cache_config_test.go
+++ b/server/cache_config_test.go
@@ -1,0 +1,116 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/Mic92/niks3/api"
+	"github.com/Mic92/niks3/server"
+	"github.com/Mic92/niks3/server/signing"
+)
+
+// Same key pair as nix/checks/nixos-test-niks3.nix — keep in sync.
+//
+//nolint:gosec // test-only key, also committed in the NixOS test fixture
+const (
+	testSigningSecret = "niks3-test-1:0knWkx/F+6IJmI4dkvNs14SCaewg9ZWSAQUNg9juRxh/8x+rzUJx9SWdyGOVl21IbJlQemUKG40qW2TTyrE++w=="
+	testSigningPublic = "niks3-test-1:f/Mfq81CcfUlnchjlZdtSGyZUHplChuNKltk08qxPvs="
+)
+
+func TestCacheConfigHandler(t *testing.T) {
+	t.Parallel()
+
+	key, err := signing.ParseKey(testSigningSecret)
+	if err != nil {
+		t.Fatalf("ParseKey: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		cacheURL string
+		keys     []*signing.Key
+		query    string
+		want     api.CacheConfig
+	}{
+		{
+			name:     "full config, no issuer",
+			cacheURL: "https://cache.example.com",
+			keys:     []*signing.Key{key},
+			query:    "",
+			want: api.CacheConfig{
+				SubstituterURL: "https://cache.example.com",
+				PublicKeys:     []string{testSigningPublic},
+			},
+		},
+		{
+			name:     "no cache url configured",
+			cacheURL: "",
+			keys:     []*signing.Key{key},
+			query:    "",
+			want: api.CacheConfig{
+				SubstituterURL: "",
+				PublicKeys:     []string{testSigningPublic},
+			},
+		},
+		{
+			name:     "no signing keys",
+			cacheURL: "https://cache.example.com",
+			keys:     nil,
+			query:    "",
+			want: api.CacheConfig{
+				SubstituterURL: "https://cache.example.com",
+				PublicKeys:     []string{},
+			},
+		},
+		{
+			name:     "issuer requested but no OIDC validator",
+			cacheURL: "https://cache.example.com",
+			keys:     []*signing.Key{key},
+			query:    "?issuer=https://token.actions.githubusercontent.com",
+			want: api.CacheConfig{
+				SubstituterURL: "https://cache.example.com",
+				PublicKeys:     []string{testSigningPublic},
+				// OIDCAudience omitted — validator is nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &server.Service{
+				CacheURL:    tt.cacheURL,
+				SigningKeys: tt.keys,
+				// OIDCValidator: nil — issuer→audience wiring is covered by
+				// oidc.TestAudienceForIssuer; constructing a Validator
+				// requires live discovery.
+			}
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/cache-config"+tt.query, nil)
+			rr := httptest.NewRecorder()
+
+			s.CacheConfigHandler(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+			}
+
+			if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+
+			var got api.CacheConfig
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/oidc/oidc_test.go
+++ b/server/oidc/oidc_test.go
@@ -54,3 +54,41 @@ func TestGlobMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestAudienceForIssuer(t *testing.T) {
+	t.Parallel()
+
+	v := &Validator{
+		config: &Config{
+			Providers: map[string]*ProviderConfig{
+				"github": {
+					Issuer:   "https://token.actions.githubusercontent.com",
+					Audience: "https://cache.example.com",
+				},
+				"gitlab": {
+					Issuer:   "https://gitlab.com",
+					Audience: "niks3",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		issuer  string
+		wantAud string
+		wantOK  bool
+	}{
+		{"https://token.actions.githubusercontent.com", "https://cache.example.com", true},
+		{"https://gitlab.com", "niks3", true},
+		{"https://unknown.example.com", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		aud, ok := v.AudienceForIssuer(tt.issuer)
+		if aud != tt.wantAud || ok != tt.wantOK {
+			t.Errorf("AudienceForIssuer(%q) = (%q, %v), want (%q, %v)",
+				tt.issuer, aud, ok, tt.wantAud, tt.wantOK)
+		}
+	}
+}

--- a/server/oidc/validator.go
+++ b/server/oidc/validator.go
@@ -95,6 +95,18 @@ func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 	return v, nil
 }
 
+// AudienceForIssuer returns the configured audience for the given issuer URL,
+// and whether a provider is configured for that issuer.
+func (v *Validator) AudienceForIssuer(issuer string) (string, bool) {
+	for _, p := range v.config.Providers {
+		if p.Issuer == issuer {
+			return p.Audience, true
+		}
+	}
+
+	return "", false
+}
+
 // ValidateToken validates a JWT token and returns the validated claims.
 // On failure, returns a *ValidationError with detailed information about why validation failed.
 func (v *Validator) ValidateToken(ctx context.Context, tokenString string) (*ValidatedClaims, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -238,6 +238,7 @@ func runServer(opts *options) error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", service.HealthCheckHandler)
+	mux.HandleFunc("GET /api/cache-config", service.CacheConfigHandler)
 
 	mux.HandleFunc("POST /api/pending_closures", service.AuthMiddleware(service.CreatePendingClosureHandler))
 	mux.HandleFunc("DELETE /api/pending_closures", service.AuthMiddleware(service.CleanupPendingClosuresHandler))


### PR DESCRIPTION
Server-side support for the [niks3 GitHub Action](https://github.com/Mic92/niks3-action).

The action handles all GitHub Actions orchestration in TypeScript: fetching this endpoint, writing nix.conf, forking `niks3-hook serve`, and draining on the post step. niks3 only provides the building blocks:

- `/api/cache-config` — unauthenticated endpoint returning substituter URL, public keys, and OIDC audience for a given issuer. Lets workflows configure themselves with only a `server-url` input.
- Drop the 30s drain batch timeout from `niks3-hook serve` — the supervisor (systemd or the CI post step) already enforces a shutdown budget and SIGKILLs on expiry; an inner timeout just abandons slow-but-progressing uploads.

Supersedes #300.

Co-authored-by: Bernardo Meurer Costa <bernardo@meurer.org>