### PR TITLE
feat(client): add TokenSource for short-lived auth tokens

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,12 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # goconst flags repeated test fixture literals (hashes, paths,
+      # HTTP methods). Hoisting them to consts makes tests harder to
+      # read for no correctness gain.
+      - linters: [goconst]
+        path: _test\.go$
 formatters:
   enable:
     - gci

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -1,0 +1,50 @@
+package client_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+// TestDoServerRequestAttachesToken verifies the Authorization header is
+// resolved from the TokenSource per request, not snapshotted at construction.
+func TestDoServerRequestAttachesToken(t *testing.T) {
+	t.Parallel()
+
+	tok := "tok-a"
+
+	var seen []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ts := client.TokenSource(func(context.Context) (string, error) { return tok, nil })
+	c := client.NewTestClientWithToken(&http.Client{}, client.DefaultRetryConfig(), ts)
+
+	for _, want := range []string{"Bearer tok-a", "Bearer tok-b"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resp, err := c.DoServerRequest(t.Context(), req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_ = resp.Body.Close()
+
+		if got := seen[len(seen)-1]; got != want {
+			t.Fatalf("Authorization = %q, want %q", got, want)
+		}
+
+		tok = "tok-b" // rotate for the next iteration
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ import (
 // Client handles uploads to the niks3 server.
 type Client struct {
 	baseURL                 *url.URL
-	authToken               string
+	tokenSource             TokenSource
 	httpClient              *http.Client
 	MaxConcurrentNARUploads int                            // Maximum number of concurrent uploads (0 = unlimited)
 	NixEnv                  []string                       // Optional environment variables for nix commands (for testing)
@@ -82,13 +82,20 @@ type ObjectWithRefs struct {
 	NarSize *uint64    `json:"nar_size,omitempty"` // For estimating multipart parts
 }
 
-// NewClient creates a new upload client.
+// NewClient creates a new upload client with a static auth token.
 // The default MaxConcurrentNARUploads is set to 16, optimized for I/O-bound upload workloads.
 // This is comparable to browser HTTP/2 connection limits and Cachix's default of 8.
 //
 // TODO: Test this value in various network setups (local network, high-latency WAN,
 // rate-limited connections) to determine optimal defaults for different scenarios.
 func NewClient(ctx context.Context, serverURL, authToken string) (*Client, error) {
+	return NewClientWithTokenSource(ctx, serverURL, StaticToken(authToken))
+}
+
+// NewClientWithTokenSource creates a new upload client that resolves its
+// auth token via ts before each server request. Use this for short-lived
+// tokens (OIDC, vault) that need to refresh during a long-running upload.
+func NewClientWithTokenSource(ctx context.Context, serverURL string, ts TokenSource) (*Client, error) {
 	baseURL, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing server URL: %w", err)
@@ -101,8 +108,8 @@ func NewClient(ctx context.Context, serverURL, authToken string) (*Client, error
 	}
 
 	return &Client{
-		baseURL:   baseURL,
-		authToken: authToken,
+		baseURL:     baseURL,
+		tokenSource: ts,
 		httpClient: &http.Client{
 			Timeout: 0, // No timeout for streaming uploads
 		},

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,10 @@ import (
 	"github.com/Mic92/niks3/ratelimit"
 )
 
+// compressionZstd is the algorithm name used in Content-Encoding headers
+// and narinfo Compression fields.
+const compressionZstd = "zstd"
+
 // Client handles uploads to the niks3 server.
 type Client struct {
 	baseURL                 *url.URL
@@ -49,7 +53,7 @@ func (t *loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	// Perform request
 	resp, err := t.transport.RoundTrip(req)
 	if err != nil {
-		return nil, err
+		return nil, err //nolint:wrapcheck // RoundTripper contract: pass error through unwrapped
 	}
 
 	// Log response

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -9,6 +9,12 @@ import (
 // ParsePathInfoJSON exports parsePathInfoJSON for testing.
 var ParsePathInfoJSON = parsePathInfoJSON
 
+// ShellSplit re-exports shellSplit for the external test package.
+var ShellSplit = shellSplit //nolint:gochecknoglobals // test-only re-export
+
+// ScriptTokenWithClock builds a ScriptToken with an injected clock for tests.
+var ScriptTokenWithClock = scriptToken //nolint:gochecknoglobals // test-only re-export
+
 // HTTPClient exposes the underlying http.Client for testing.
 func (c *Client) HTTPClient() *http.Client {
 	return c.httpClient
@@ -16,8 +22,14 @@ func (c *Client) HTTPClient() *http.Client {
 
 // NewTestClient creates a Client for testing with a custom HTTP client and retry config.
 func NewTestClient(httpClient *http.Client, retry RetryConfig) *Client {
+	return NewTestClientWithToken(httpClient, retry, StaticToken(""))
+}
+
+// NewTestClientWithToken is like NewTestClient but with an explicit TokenSource.
+func NewTestClientWithToken(httpClient *http.Client, retry RetryConfig, ts TokenSource) *Client {
 	return &Client{
 		httpClient:        httpClient,
+		tokenSource:       ts,
 		Retry:             retry,
 		S3RateLimiter:     ratelimit.NewAdaptiveRateLimiter(0, "s3-test"),
 		ServerRateLimiter: ratelimit.NewAdaptiveRateLimiter(0, "server-test"),

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ParsePathInfoJSON exports parsePathInfoJSON for testing.
-var ParsePathInfoJSON = parsePathInfoJSON
+var ParsePathInfoJSON = parsePathInfoJSON //nolint:gochecknoglobals // test-only re-export
 
 // ShellSplit re-exports shellSplit for the external test package.
 var ShellSplit = shellSplit //nolint:gochecknoglobals // test-only re-export

--- a/client/gc.go
+++ b/client/gc.go
@@ -119,7 +119,7 @@ func (c *Client) RunGarbageCollection(ctx context.Context, olderThan string, fai
 	for status.State == api.GCTaskStateRunning {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, ctx.Err() //nolint:wrapcheck // ctx.Err() is the canonical sentinel for cancellation
 		case <-time.After(gcPollInterval):
 		}
 

--- a/client/gc.go
+++ b/client/gc.go
@@ -46,8 +46,6 @@ func (c *Client) StartGarbageCollection(ctx context.Context, olderThan string, f
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
-
 	resp, err := c.DoServerRequest(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
@@ -86,8 +84,6 @@ func (c *Client) GetGCStatus(ctx context.Context) (*api.GCTaskStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 
 	resp, err := c.DoServerRequest(ctx, req)
 	if err != nil {
@@ -133,7 +129,8 @@ func (c *Client) RunGarbageCollection(ctx context.Context, olderThan string, fai
 		}
 
 		if status.Phase != lastPhase || status.Stats != lastStats {
-			slog.Info("Garbage collection progress",
+			slog.Info(
+				"Garbage collection progress",
 				"phase", status.Phase,
 				"failed_uploads_deleted", status.Stats.FailedUploadsDeleted,
 				"old_closures_deleted", status.Stats.OldClosuresDeleted,

--- a/client/metadata_tasks.go
+++ b/client/metadata_tasks.go
@@ -97,7 +97,7 @@ func (c *Client) uploadRealisation(ctx context.Context, task uploadTask, realisa
 
 	// Upload with Content-Encoding header
 	headers := map[string]string{
-		"Content-Encoding": "zstd",
+		"Content-Encoding": compressionZstd,
 	}
 
 	if err := c.UploadBytesToPresignedURLWithHeaders(ctx, task.obj.PresignedURL, compressed, headers); err != nil {

--- a/client/multipart.go
+++ b/client/multipart.go
@@ -96,7 +96,6 @@ func (c *Client) RequestMoreParts(ctx context.Context, objectKey, uploadID strin
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.DoServerRequest(ctx, req)
@@ -155,7 +154,6 @@ func (c *Client) CompleteMultipartUpload(ctx context.Context, objectKey, uploadI
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.DoServerRequest(ctx, req)

--- a/client/nar_test.go
+++ b/client/nar_test.go
@@ -164,6 +164,7 @@ func TestDumpPathSingleFile(t *testing.T) {
 	}
 
 	f := filepath.Join(tmp, "single")
+	//nolint:gosec // 0o755 is intentional: NAR encoding records the executable bit
 	if err := os.WriteFile(f, bytes.Repeat([]byte("x"), 12345), 0o755); err != nil {
 		t.Fatalf("write: %v", err)
 	}

--- a/client/nixstore.go
+++ b/client/nixstore.go
@@ -222,7 +222,8 @@ type RealisationInfo struct {
 
 // GetPathInfoRecursive queries Nix for path info including all dependencies.
 func GetPathInfoRecursive(ctx context.Context, storePaths []string, nixEnv []string) (map[string]*PathInfo, error) {
-	args := []string{"--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--"}
+	args := make([]string, 0, 6+len(storePaths))
+	args = append(args, "--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--")
 	args = append(args, storePaths...)
 
 	cmd := exec.CommandContext(ctx, "nix", args...)

--- a/client/nixstore_test.go
+++ b/client/nixstore_test.go
@@ -336,23 +336,26 @@ func TestPathInfoCACompatibility(t *testing.T) {
 				return
 			}
 
-			if !tt.wantErr {
-				if tt.expectNil {
-					if pathInfo.CA != nil {
-						t.Errorf("Expected CA to be nil, but got: %v", pathInfo.CA)
-					}
-				} else {
-					if pathInfo.CA == nil {
-						t.Errorf("Expected CA to be non-nil")
+			if tt.wantErr {
+				return
+			}
 
-						return
-					}
-
-					caStr := pathInfo.CA.String()
-					if caStr != tt.expectedCAStr {
-						t.Errorf("CA.String() = %q, want %q", caStr, tt.expectedCAStr)
-					}
+			if tt.expectNil {
+				if pathInfo.CA != nil {
+					t.Errorf("Expected CA to be nil, but got: %v", pathInfo.CA)
 				}
+
+				return
+			}
+
+			if pathInfo.CA == nil {
+				t.Errorf("Expected CA to be non-nil")
+
+				return
+			}
+
+			if caStr := pathInfo.CA.String(); caStr != tt.expectedCAStr {
+				t.Errorf("CA.String() = %q, want %q", caStr, tt.expectedCAStr)
 			}
 		})
 	}

--- a/client/parallel.go
+++ b/client/parallel.go
@@ -123,7 +123,7 @@ func (c *Client) UploadPendingObjects(ctx context.Context, uploadCtx *UploadCont
 
 	// Wait for phase 1 to complete
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, err //nolint:wrapcheck // errgroup returns the first task's already-wrapped error
 	}
 
 	// Phase 2: Collect narinfo metadata for successfully uploaded NARs
@@ -163,7 +163,7 @@ func (c *Client) UploadPendingObjects(ctx context.Context, uploadCtx *UploadCont
 		metadata := NarinfoMetadata{
 			StorePath:   pathInfo.Path,
 			URL:         narURL,
-			Compression: "zstd",
+			Compression: compressionZstd,
 			NarHash:     narHash,
 			NarSize:     pathInfo.NarSize,
 			References:  pathInfo.References,

--- a/client/pending_closure.go
+++ b/client/pending_closure.go
@@ -50,7 +50,6 @@ func (c *Client) CreatePendingClosure(ctx context.Context, closure string, objec
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.DoServerRequest(ctx, req)
@@ -98,7 +97,6 @@ func (c *Client) CompletePendingClosure(ctx context.Context, closureID string) e
 		return fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.DoServerRequest(ctx, req)
@@ -143,7 +141,6 @@ func (c *Client) SignPendingClosure(ctx context.Context, closureID string, narin
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.authToken)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.DoServerRequest(ctx, req)

--- a/client/retry.go
+++ b/client/retry.go
@@ -239,7 +239,7 @@ func (c *Client) doWithRetry(ctx context.Context, req *http.Request, limiter *ra
 		}
 
 		// Execute request
-		resp, err := c.httpClient.Do(req)
+		resp, err := c.httpClient.Do(req) //nolint:gosec // G704: req.URL is the configured server endpoint, not attacker input
 
 		// Update rate limiter regardless of whether we retry
 		if err == nil {
@@ -347,7 +347,7 @@ func (c *Client) doOnce(ctx context.Context, req *http.Request, limiter *ratelim
 		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: req.URL is the configured server endpoint, not attacker input
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
 	}

--- a/client/retry.go
+++ b/client/retry.go
@@ -147,8 +147,20 @@ func retryAfterDuration(resp *http.Response) time.Duration {
 	return 0
 }
 
-// DoServerRequest executes an HTTP request to the niks3 server with rate limiting and retry.
+// DoServerRequest executes an HTTP request to the niks3 server with rate
+// limiting, retry, and auth. The Authorization header is resolved from the
+// client's TokenSource immediately before the request so short-lived tokens
+// (OIDC, vault) stay fresh across long uploads.
 func (c *Client) DoServerRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	tok, err := c.tokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolving auth token: %w", err)
+	}
+
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
 	return c.doWithRetry(ctx, req, c.ServerRateLimiter)
 }
 

--- a/client/shellsplit.go
+++ b/client/shellsplit.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+// shellSplit tokenises s like a POSIX shell would, honouring single quotes,
+// double quotes, and backslash escapes. It does NOT do parameter expansion,
+// globbing, or command substitution — this runs on a credential command
+// string, where surprise expansion would be a security footgun.
+//
+// Semantics:
+//   - whitespace outside quotes separates words
+//   - 'single quoted' text is taken literally; backslash is not special
+//   - "double quoted" text allows backslash to escape the next byte
+//   - backslash outside quotes escapes the next byte
+//   - adjacent fragments concatenate: a"b"'c' ⇒ abc
+//
+// Returns an error on an unterminated quote or trailing backslash.
+func shellSplit(s string) ([]string, error) {
+	var (
+		words   []string
+		cur     strings.Builder
+		started bool // cur holds a word in progress (handles "" as a word)
+	)
+
+	const (
+		stPlain = iota
+		stSingle
+		stDouble
+	)
+
+	state := stPlain
+	escaped := false
+
+	for _, r := range s {
+		if escaped {
+			cur.WriteRune(r)
+
+			started = true
+			escaped = false
+
+			continue
+		}
+
+		switch state {
+		case stPlain:
+			switch r {
+			case '\\':
+				escaped = true
+				started = true
+			case '\'':
+				state = stSingle
+				started = true
+			case '"':
+				state = stDouble
+				started = true
+			case ' ', '\t', '\n':
+				if started {
+					words = append(words, cur.String())
+					cur.Reset()
+
+					started = false
+				}
+			default:
+				cur.WriteRune(r)
+
+				started = true
+			}
+		case stSingle:
+			if r == '\'' {
+				state = stPlain
+			} else {
+				cur.WriteRune(r)
+			}
+		case stDouble:
+			switch r {
+			case '\\':
+				escaped = true
+			case '"':
+				state = stPlain
+			default:
+				cur.WriteRune(r)
+			}
+		}
+	}
+
+	if escaped {
+		return nil, fmt.Errorf("trailing backslash in %q", s)
+	}
+
+	if state != stPlain {
+		return nil, fmt.Errorf("unterminated quote in %q", s)
+	}
+
+	if started {
+		words = append(words, cur.String())
+	}
+
+	return words, nil
+}

--- a/client/shellsplit_test.go
+++ b/client/shellsplit_test.go
@@ -1,0 +1,67 @@
+package client_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+const (
+	ab  = "a b"
+	abc = "abc"
+)
+
+func TestShellSplit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"a b c", []string{"a", "b", "c"}},
+		{"a  b\tc\n", []string{"a", "b", "c"}},
+		{"'a b' c", []string{ab, "c"}},
+		{`"a b" c`, []string{ab, "c"}},
+		{`a\ b c`, []string{ab, "c"}},
+		{`a"b"'c'`, []string{abc}},
+		{`""`, []string{""}},
+		{`''`, []string{""}},
+		// Single quotes are literal: no escape, no nesting.
+		{`'a\nb'`, []string{`a\nb`}},
+		// Double quotes allow backslash escapes.
+		{`"a\"b"`, []string{`a"b`}},
+		{`"a\\b"`, []string{`a\b`}},
+		// No expansion of any kind.
+		{`$HOME`, []string{"$HOME"}},
+		{"`whoami`", []string{"`whoami`"}},
+		// Realistic credential commands.
+		{`vault token lookup -format=json`, []string{"vault", "token", "lookup", "-format=json"}},
+		{`sh -c 'curl -s "$URL" | jq .token'`, []string{"sh", "-c", `curl -s "$URL" | jq .token`}},
+	}
+
+	for _, tc := range cases {
+		got, err := client.ShellSplit(tc.in)
+		if err != nil {
+			t.Errorf("shellSplit(%q): unexpected error %v", tc.in, err)
+
+			continue
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("shellSplit(%q) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestShellSplitErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{`'open`, `"open`, `trail\`} {
+		if _, err := client.ShellSplit(in); err == nil {
+			t.Errorf("shellSplit(%q): expected error", in)
+		}
+	}
+}

--- a/client/simple_uploads.go
+++ b/client/simple_uploads.go
@@ -47,7 +47,7 @@ func (c *Client) UploadListingToPresignedURL(ctx context.Context, presignedURL s
 
 	// Upload with Content-Encoding header
 	headers := map[string]string{
-		"Content-Encoding": "zstd",
+		"Content-Encoding": compressionZstd,
 	}
 
 	return c.UploadBytesToPresignedURLWithHeaders(ctx, presignedURL, compressed, headers)
@@ -113,7 +113,7 @@ func (c *Client) UploadBuildLogToPresignedURL(ctx context.Context, presignedURL 
 
 	// Set headers
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
-	req.Header.Set("Content-Encoding", "zstd")
+	req.Header.Set("Content-Encoding", compressionZstd)
 
 	// Upload
 	resp, err := c.DoS3Request(ctx, req)

--- a/client/token.go
+++ b/client/token.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TokenSource yields a bearer token for authenticating to the niks3 server.
+//
+// Implementations may cache; callers should treat each call as cheap and
+// invoke it immediately before issuing a request rather than holding the
+// result.
+type TokenSource func(ctx context.Context) (string, error)
+
+// StaticToken returns a TokenSource that always yields tok and never refreshes.
+// An empty tok is valid: it represents anonymous access.
+func StaticToken(tok string) TokenSource {
+	return func(context.Context) (string, error) { return tok, nil }
+}
+
+// fileRereadInterval bounds how often FileToken hits the filesystem when
+// the cache is warm. Mirrors client-go's CachedFileTokenSource (1 min poll
+// for projected service account tokens).
+const fileRereadInterval = time.Minute
+
+// FileToken returns a TokenSource that re-reads path lazily.
+//
+// The file is re-read at most once per minute. This matches the Kubernetes
+// bound-service-account-token pattern: an external process (systemd timer,
+// vault-agent, kubelet) keeps the file fresh; the consumer only needs to
+// notice eventually.
+//
+// Trailing whitespace is trimmed. An empty file is an error: a token file
+// that exists is expected to hold a token.
+func FileToken(path string) TokenSource {
+	var (
+		mu     sync.Mutex
+		cached string
+		readAt time.Time
+	)
+
+	return func(context.Context) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if cached != "" && time.Since(readAt) < fileRereadInterval {
+			return cached, nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("reading auth token file %q: %w", path, err)
+		}
+
+		tok := strings.TrimSpace(string(data))
+		if tok == "" {
+			return "", fmt.Errorf("auth token file %q is empty", path)
+		}
+
+		cached, readAt = tok, time.Now()
+
+		return tok, nil
+	}
+}
+
+// scriptOutput is the JSON document a token script must print to stdout.
+// Logs and progress should go to stderr; stdout must contain exactly one
+// JSON object. This mirrors the Kubernetes ExecCredential and AWS
+// credential_process conventions, which proved easier to author and debug
+// than marker-line protocols.
+type scriptOutput struct {
+	Token string `json:"token"`
+	// ExpiresAt, when set, lets niks3 cache the token and refresh before
+	// expiry. RFC 3339. When absent the script is rerun on every Token call,
+	// which is the right behavior for scripts that cache internally (aws
+	// sts, vault).
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// scriptRefreshFraction controls how early to refresh relative to the
+// observed token lifetime. 0.75 means refresh after 75% of the lifetime has
+// elapsed — same heuristic kubelet uses for projected tokens.
+const scriptRefreshFraction = 0.75
+
+// ScriptToken returns a TokenSource that obtains tokens by running a command.
+//
+// The command string is split with shell-like quoting rules (single/double
+// quotes, backslash escapes — but no expansion or substitution) and exec'd
+// directly, matching the AWS credential_process and Kubernetes ExecCredential
+// conventions. It must print a JSON object to stdout (see scriptOutput) and
+// may log freely to stderr. When the output carries expires_at the token is
+// cached until 75% of its lifetime has elapsed; otherwise the command runs on
+// every Token call.
+//
+// Wrap in `sh -c '...'` explicitly if shell features (pipes, variables) are
+// needed.
+func ScriptToken(script string) TokenSource {
+	return scriptToken(script, time.Now)
+}
+
+func scriptToken(script string, now func() time.Time) TokenSource {
+	var (
+		mu        sync.Mutex
+		cached    string
+		refreshAt time.Time // zero ⇒ no caching
+	)
+
+	return func(ctx context.Context) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if cached != "" && !refreshAt.IsZero() && now().Before(refreshAt) {
+			return cached, nil
+		}
+
+		out, err := runTokenScript(ctx, script)
+		if err != nil {
+			return "", err
+		}
+
+		if out.Token == "" {
+			return "", errors.New("auth token script returned empty token")
+		}
+
+		cached, refreshAt = out.Token, time.Time{}
+
+		if out.ExpiresAt != nil {
+			if lifetime := out.ExpiresAt.Sub(now()); lifetime > 0 {
+				refreshAt = now().Add(time.Duration(float64(lifetime) * scriptRefreshFraction))
+			}
+		}
+
+		return cached, nil
+	}
+}
+
+func runTokenScript(ctx context.Context, script string) (*scriptOutput, error) {
+	argv, err := shellSplit(script)
+	if err != nil {
+		return nil, fmt.Errorf("parsing auth token script: %w", err)
+	}
+
+	if len(argv) == 0 {
+		return nil, errors.New("auth token script is empty")
+	}
+
+	//nolint:gosec // command is user-provided config, like git's credential.helper
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("running auth token script: %w", err)
+	}
+
+	var out scriptOutput
+	if err := json.Unmarshal(stdout, &out); err != nil {
+		return nil, fmt.Errorf("parsing auth token script output (expected JSON object on stdout): %w", err)
+	}
+
+	return &out, nil
+}

--- a/client/token_test.go
+++ b/client/token_test.go
@@ -1,0 +1,212 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/client"
+)
+
+const (
+	tok1 = "tok-1"
+	tok2 = "tok-2"
+)
+
+func TestStaticToken(t *testing.T) {
+	t.Parallel()
+
+	const tok = "static-abc"
+
+	if got := mustToken(t, client.StaticToken(tok)); got != tok {
+		t.Fatalf("got %q, want %s", got, tok)
+	}
+}
+
+func TestFileTokenReadsAndCaches(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tok")
+	writeFile(t, path, "first\n")
+
+	ts := client.FileToken(path)
+
+	if got := mustToken(t, ts); got != "first" {
+		t.Fatalf("got %q, want first", got)
+	}
+
+	// Change the file. Within the reread interval the cached value sticks.
+	writeFile(t, path, "second\n")
+
+	if got := mustToken(t, ts); got != "first" {
+		t.Fatalf("cached read changed: got %q, want first", got)
+	}
+}
+
+func TestFileTokenMissing(t *testing.T) {
+	t.Parallel()
+
+	ts := client.FileToken(filepath.Join(t.TempDir(), "nope"))
+
+	if _, err := ts(t.Context()); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestFileTokenEmpty(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "tok")
+	writeFile(t, path, "  \n")
+
+	if _, err := client.FileToken(path)(t.Context()); err == nil {
+		t.Fatal("expected error for empty token file")
+	}
+}
+
+func TestScriptTokenNoExpiryRerunsEveryCall(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "n")
+	writeFile(t, counter, "0")
+
+	// Script bumps a counter and emits it as the token, so we can observe
+	// reruns. No expires_at ⇒ no caching.
+	ts := client.ScriptToken(counterScript(t, dir, counter, ""))
+
+	if got := mustToken(t, ts); got != tok1 {
+		t.Fatalf("got %q, want %s", got, tok1)
+	}
+
+	if got := mustToken(t, ts); got != tok2 {
+		t.Fatalf("got %q, want %s (script should rerun)", got, tok2)
+	}
+}
+
+func TestScriptTokenCachesUntilRefresh(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "n")
+	writeFile(t, counter, "0")
+
+	// Token expires 100s from "now"; refresh at 75% ⇒ 75s.
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expires := now.Add(100 * time.Second).Format(time.RFC3339)
+
+	ts := client.ScriptTokenWithClock(counterScript(t, dir, counter, expires), func() time.Time { return now })
+
+	if got := mustToken(t, ts); got != tok1 {
+		t.Fatalf("got %q, want %s", got, tok1)
+	}
+
+	// Before the 75% mark: cached.
+	now = now.Add(74 * time.Second)
+
+	if got := mustToken(t, ts); got != tok1 {
+		t.Fatalf("got %q, want %s (still cached)", got, tok1)
+	}
+
+	// After the 75% mark: refreshed.
+	now = now.Add(2 * time.Second)
+
+	if got := mustToken(t, ts); got != tok2 {
+		t.Fatalf("got %q, want %s (should refresh)", got, tok2)
+	}
+}
+
+func TestScriptTokenEmptyToken(t *testing.T) {
+	t.Parallel()
+
+	cmd := echoScript(t, t.TempDir(), `{"token":""}`)
+	if _, err := client.ScriptToken(cmd)(t.Context()); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestScriptTokenBadJSON(t *testing.T) {
+	t.Parallel()
+
+	cmd := echoScript(t, t.TempDir(), "not-json")
+	if _, err := client.ScriptToken(cmd)(t.Context()); err == nil {
+		t.Fatal("expected error for non-JSON output")
+	}
+}
+
+func TestScriptTokenScriptFails(t *testing.T) {
+	t.Parallel()
+
+	if _, err := client.ScriptToken("false")(t.Context()); err == nil {
+		t.Fatal("expected error for failing script")
+	}
+}
+
+func TestScriptTokenEmptyCommand(t *testing.T) {
+	t.Parallel()
+
+	if _, err := client.ScriptToken("   ")(t.Context()); err == nil {
+		t.Fatal("expected error for empty command")
+	}
+}
+
+// counterScript writes a shell helper that bumps a counter file and prints
+// scriptOutput JSON with the count baked into the token. expires is an RFC
+// 3339 timestamp or "" to omit the field.
+func counterScript(t *testing.T, dir, counter, expires string) string {
+	t.Helper()
+
+	var exp string
+	if expires != "" {
+		exp = fmt.Sprintf(`,"expires_at":"%s"`, expires)
+	}
+
+	body := fmt.Sprintf(
+		"#!/bin/sh\nn=$(($(cat %q)+1)); echo \"$n\" > %q; printf '{\"token\":\"tok-%%s\"%s}' \"$n\"\n",
+		counter, counter, exp,
+	)
+
+	return writeScript(t, dir, "counter.sh", body)
+}
+
+func echoScript(t *testing.T, dir, out string) string {
+	t.Helper()
+
+	return writeScript(t, dir, "echo.sh", "#!/bin/sh\nprintf '%s' "+fmt.Sprintf("%q", out)+"\n")
+}
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invoke via sh rather than exec'ing the file directly. Avoids ETXTBSY
+	// when another parallel test forks while this WriteFile fd is briefly
+	// open (fds are inherited until close-on-exec).
+	return "sh " + path
+}
+
+func mustToken(t *testing.T, ts client.TokenSource) string {
+	t.Helper()
+
+	tok, err := ts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tok
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/client/upload.go
+++ b/client/upload.go
@@ -413,7 +413,7 @@ func (c *Client) uploadNarinfosInParallel(ctx context.Context, narinfos []narinf
 		})
 	}
 
-	return g.Wait()
+	return g.Wait() //nolint:wrapcheck // errgroup returns the first task's already-wrapped error
 }
 
 // PushPaths uploads store paths and their closures to the server.

--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -207,7 +207,7 @@ func runServe() error {
 	}
 
 	if err := tf.Configure(c); err != nil {
-		return err
+		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
 	c.MaxConcurrentNARUploads = *maxConcurrent

--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -56,6 +56,7 @@ func printServeHelp() {
 	fmt.Fprintln(os.Stderr, "        Server URL (can also use NIKS3_SERVER_URL env var)")
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenHelp)
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenPathHelp)
+	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenScriptHelp)
 	fmt.Fprintf(os.Stderr, "  --socket string\n        Unix socket path (default: %s)\n", hook.DefaultSocketPath)
 	fmt.Fprintln(os.Stderr, "  --db-path string")
 	fmt.Fprintln(os.Stderr, "        SQLite database path (default: /var/lib/niks3-hook/upload-queue.db)")
@@ -135,14 +136,8 @@ func runSend() error {
 }
 
 func runServe() error {
-	defaultAuthToken, err := cmdutil.GetAuthToken()
-	if err != nil {
-		return err //nolint:wrapcheck // cmdutil errors are already user-facing
-	}
-
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
-	cf := cmdutil.AddCommonFlags(fs, defaultAuthToken)
-	authTokenPath := fs.String("auth-token-path", "", "Path to auth token file")
+	cf := cmdutil.AddCommonFlags(fs)
 	socket := fs.String("socket", hook.DefaultSocketPath, "Unix socket path")
 	dbPath := fs.String("db-path", "/var/lib/niks3-hook/upload-queue.db", "SQLite database path")
 	batchSize := fs.Int("batch-size", 50, "Paths per upload batch")
@@ -171,12 +166,8 @@ func runServe() error {
 		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
-	token, err := cmdutil.ResolveAuthToken(*cf.AuthToken, *authTokenPath)
+	ts, err := cf.TokenSource(fs)
 	if err != nil {
-		return err //nolint:wrapcheck // cmdutil errors are already user-facing
-	}
-
-	if err := cmdutil.RequireAuthToken(token); err != nil {
 		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
@@ -210,7 +201,7 @@ func runServe() error {
 	defer stop()
 
 	// Create the niks3 client.
-	c, err := client.NewClient(ctx, *cf.ServerURL, token)
+	c, err := client.NewClientWithTokenSource(ctx, *cf.ServerURL, ts)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
@@ -263,7 +254,8 @@ func runServe() error {
 		defer func() { _ = os.Remove(*socket) }()
 	}
 
-	slog.Info("niks3-hook serve starting",
+	slog.Info(
+		"niks3-hook serve starting",
 		"socket", *socket,
 		"socket-activated", activated,
 		"db-path", *dbPath,

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -112,7 +112,7 @@ func run() error {
 		cmdutil.SetupLogger(*cf.Debug)
 
 		if err := cmdutil.RequireServerURL(*cf.ServerURL); err != nil {
-			return err
+			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
 		ts, err := cf.TokenSource(pushCmd)
@@ -152,7 +152,7 @@ func run() error {
 		cmdutil.SetupLogger(*cf.Debug)
 
 		if err := cmdutil.RequireServerURL(*cf.ServerURL); err != nil {
-			return err
+			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
 		ts, err := cf.TokenSource(gcCmd)
@@ -181,7 +181,7 @@ func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxCon
 	}
 
 	if err := tf.Configure(c); err != nil {
-		return err
+		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
 	c.MaxConcurrentNARUploads = maxConcurrent
@@ -208,7 +208,7 @@ func gcCommand(serverURL string, ts client.TokenSource, olderThan, pendingOlderT
 	}
 
 	if err := tf.Configure(c); err != nil {
-		return err
+		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
 	if debug {

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -38,6 +38,8 @@ func printPushHelp() {
 	fmt.Fprintln(os.Stderr, "  --server-url string")
 	fmt.Fprintln(os.Stderr, "        Server URL (can also use NIKS3_SERVER_URL env var)")
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenHelp)
+	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenPathHelp)
+	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenScriptHelp)
 	fmt.Fprintln(os.Stderr, "  --max-concurrent-uploads int")
 	fmt.Fprintln(os.Stderr, "        Maximum concurrent uploads (default: 30)")
 	fmt.Fprintln(os.Stderr, "  --verify-s3-integrity")
@@ -57,6 +59,7 @@ func printGcHelp() {
 	fmt.Fprintln(os.Stderr, "        Server URL (can also use NIKS3_SERVER_URL env var)")
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenHelp)
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenPathHelp)
+	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenScriptHelp)
 	fmt.Fprintln(os.Stderr, "  --older-than string")
 	fmt.Fprintln(os.Stderr, "        Delete closures older than this duration (default: '720h' for 30 days)")
 	fmt.Fprintln(os.Stderr, "  --failed-uploads-older-than string")
@@ -84,17 +87,10 @@ func run() error {
 		os.Exit(0)
 	}
 
-	// Get default auth token from environment/XDG (after help check so
-	// --help never reads auth files or produces auth errors).
-	defaultAuthToken, err := cmdutil.GetAuthToken()
-	if err != nil {
-		return err
-	}
-
 	switch os.Args[1] {
 	case "push":
 		pushCmd := flag.NewFlagSet("push", flag.ContinueOnError)
-		cf := cmdutil.AddCommonFlags(pushCmd, defaultAuthToken)
+		cf := cmdutil.AddCommonFlags(pushCmd)
 		maxConcurrent := pushCmd.Int("max-concurrent-uploads", 30, "Maximum concurrent uploads")
 		verifyS3Integrity := pushCmd.Bool("verify-s3-integrity", false, "Verify S3 integrity")
 		tf := cmdutil.AddTLSFlags(pushCmd)
@@ -119,8 +115,9 @@ func run() error {
 			return err
 		}
 
-		if err := cmdutil.RequireAuthToken(*cf.AuthToken); err != nil {
-			return err
+		ts, err := cf.TokenSource(pushCmd)
+		if err != nil {
+			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
 		paths := pushCmd.Args()
@@ -128,12 +125,11 @@ func run() error {
 			return errors.New("at least one store path is required")
 		}
 
-		return pushCommand(*cf.ServerURL, *cf.AuthToken, paths, *maxConcurrent, *verifyS3Integrity, *cf.Debug, tf)
+		return pushCommand(*cf.ServerURL, ts, paths, *maxConcurrent, *verifyS3Integrity, *cf.Debug, tf)
 
 	case "gc":
 		gcCmd := flag.NewFlagSet("gc", flag.ContinueOnError)
-		cf := cmdutil.AddCommonFlags(gcCmd, defaultAuthToken)
-		authTokenPath := gcCmd.String("auth-token-path", "", "Path to auth token file")
+		cf := cmdutil.AddCommonFlags(gcCmd)
 		olderThan := gcCmd.String("older-than", "720h", "Delete closures older than this duration")
 		pendingOlderThan := gcCmd.String("failed-uploads-older-than", "6h", "Delete failed uploads older than this duration")
 		force := gcCmd.Bool("force", false, "Force immediate deletion without grace period")
@@ -159,23 +155,19 @@ func run() error {
 			return err
 		}
 
-		token, err := cmdutil.ResolveAuthToken(*cf.AuthToken, *authTokenPath)
+		ts, err := cf.TokenSource(gcCmd)
 		if err != nil {
-			return err
+			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
-		if err := cmdutil.RequireAuthToken(token); err != nil {
-			return err
-		}
-
-		return gcCommand(*cf.ServerURL, token, *olderThan, *pendingOlderThan, *force, *cf.Debug, tf)
+		return gcCommand(*cf.ServerURL, ts, *olderThan, *pendingOlderThan, *force, *cf.Debug, tf)
 
 	default:
 		return fmt.Errorf("unknown command: %s", os.Args[1])
 	}
 }
 
-func pushCommand(serverURL, authToken string, paths []string, maxConcurrent int, verifyS3Integrity bool, debug bool, tf cmdutil.TLSFlags) error {
+func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxConcurrent int, verifyS3Integrity bool, debug bool, tf cmdutil.TLSFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -183,7 +175,7 @@ func pushCommand(serverURL, authToken string, paths []string, maxConcurrent int,
 		maxConcurrent = 1
 	}
 
-	c, err := client.NewClient(ctx, serverURL, authToken)
+	c, err := client.NewClientWithTokenSource(ctx, serverURL, ts)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
@@ -206,11 +198,11 @@ func pushCommand(serverURL, authToken string, paths []string, maxConcurrent int,
 	return nil
 }
 
-func gcCommand(serverURL, authToken, olderThan, pendingOlderThan string, force bool, debug bool, tf cmdutil.TLSFlags) error {
+func gcCommand(serverURL string, ts client.TokenSource, olderThan, pendingOlderThan string, force bool, debug bool, tf cmdutil.TLSFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	c, err := client.NewClient(ctx, serverURL, authToken)
+	c, err := client.NewClientWithTokenSource(ctx, serverURL, ts)
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
 	}
@@ -235,7 +227,8 @@ func gcCommand(serverURL, authToken, olderThan, pendingOlderThan string, force b
 		return fmt.Errorf("running garbage collection: %w", err)
 	}
 
-	slog.Info("Garbage collection completed successfully",
+	slog.Info(
+		"Garbage collection completed successfully",
 		"failed-uploads-deleted", stats.FailedUploadsDeleted,
 		"old-closures-deleted", stats.OldClosuresDeleted,
 		"objects-marked-for-deletion", stats.ObjectsMarkedForDeletion,

--- a/cmdutil/cmdutil.go
+++ b/cmdutil/cmdutil.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/Mic92/niks3/client"
 )
@@ -40,65 +39,86 @@ func DefaultAuthTokenPath() string {
 	return filepath.Join(configDir, "niks3", "auth-token")
 }
 
-// GetAuthToken reads the auth token from NIKS3_AUTH_TOKEN_FILE or the default XDG path.
-// The file should contain the token as a single line (trailing whitespace is trimmed).
-func GetAuthToken() (string, error) {
-	tokenFile := os.Getenv("NIKS3_AUTH_TOKEN_FILE")
-	if tokenFile == "" {
-		tokenFile = DefaultAuthTokenPath()
-		if tokenFile == "" {
-			return "", nil
-		}
-
-		if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
-			return "", nil
-		}
+// envAuthTokenPath returns the token file from NIKS3_AUTH_TOKEN_FILE or the
+// XDG default path, or "" if neither is set / the default doesn't exist.
+func envAuthTokenPath() string {
+	if p := os.Getenv("NIKS3_AUTH_TOKEN_FILE"); p != "" {
+		return p
 	}
 
-	data, err := os.ReadFile(tokenFile) //nolint:gosec // token path is user-provided config, not attacker-controlled
-	if err != nil {
-		return "", fmt.Errorf("reading auth token from file %q: %w", tokenFile, err)
+	p := DefaultAuthTokenPath()
+	if p == "" {
+		return ""
 	}
 
-	return strings.TrimSpace(string(data)), nil
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return ""
+	}
+
+	return p
 }
 
-// ResolveAuthToken returns the token from the file at flagTokenPath if set,
-// otherwise falls back to flagToken (from --auth-token or the env/XDG default).
-func ResolveAuthToken(flagToken, flagTokenPath string) (string, error) {
-	if flagTokenPath != "" {
-		data, err := os.ReadFile(flagTokenPath)
-		if err != nil {
-			return "", fmt.Errorf("reading auth token file: %w", err)
-		}
-
-		return strings.TrimSpace(string(data)), nil
+// ResolveTokenSource picks a client.TokenSource from the auth flags, in
+// priority order: script > file > literal token > env/XDG file. All file
+// sources (--auth-token-path, NIKS3_AUTH_TOKEN_FILE, the XDG default) get
+// the same FileToken behavior with periodic re-reads, so an external
+// refresher rotating the file works regardless of how the path was supplied.
+func ResolveTokenSource(flagToken, flagTokenPath, flagTokenScript string) (client.TokenSource, error) {
+	switch {
+	case flagTokenScript != "":
+		return client.ScriptToken(flagTokenScript), nil
+	case flagTokenPath != "":
+		return client.FileToken(flagTokenPath), nil
+	case flagToken != "":
+		return client.StaticToken(flagToken), nil
 	}
 
-	return flagToken, nil
+	if p := envAuthTokenPath(); p != "" {
+		return client.FileToken(p), nil
+	}
+
+	return nil, errors.New("auth token is required (use --auth-token-path, --auth-token-script, NIKS3_AUTH_TOKEN_FILE, or $XDG_CONFIG_HOME/niks3/auth-token)")
 }
 
 // CommonFlags holds pointers to flags shared across subcommands.
 type CommonFlags struct {
-	ServerURL *string
-	AuthToken *string
-	Debug     *bool
-	Help      *bool
+	ServerURL       *string
+	AuthToken       *string
+	AuthTokenPath   *string
+	AuthTokenScript *string
+	Debug           *bool
+	Help            *bool
 }
 
-// AddCommonFlags registers --server-url, --auth-token, --debug, and -h/--help
-// on the given FlagSet and returns pointers to them.
-func AddCommonFlags(fs *flag.FlagSet, defaultAuthToken string) CommonFlags {
+// AddCommonFlags registers --server-url, the auth flags, --debug, and
+// -h/--help on the given FlagSet and returns pointers to them.
+func AddCommonFlags(fs *flag.FlagSet) CommonFlags {
 	fs.Usage = func() {} // Suppress default usage; each command prints its own.
 	cf := CommonFlags{
-		ServerURL: fs.String("server-url", os.Getenv("NIKS3_SERVER_URL"), "Server URL"),
-		AuthToken: fs.String("auth-token", defaultAuthToken, "Auth token"),
-		Debug:     fs.Bool("debug", false, "Enable debug logging"),
-		Help:      fs.Bool("help", false, "Show help"),
+		ServerURL:       fs.String("server-url", os.Getenv("NIKS3_SERVER_URL"), "Server URL"),
+		AuthToken:       fs.String("auth-token", "", "Auth token (deprecated)"),
+		AuthTokenPath:   fs.String("auth-token-path", "", "Path to auth token file"),
+		AuthTokenScript: fs.String("auth-token-script", "", "Command that emits a token JSON document"),
+		Debug:           fs.Bool("debug", false, "Enable debug logging"),
+		Help:            fs.Bool("help", false, "Show help"),
 	}
 	fs.BoolVar(cf.Help, "h", false, "Show help")
 
 	return cf
+}
+
+// TokenSource resolves the auth flags via ResolveTokenSource and warns if
+// the deprecated --auth-token flag was set explicitly on the command line
+// (as opposed to being filled in from NIKS3_AUTH_TOKEN_FILE or the XDG
+// default). fs must be the FlagSet the flags were registered on.
+func (cf CommonFlags) TokenSource(fs *flag.FlagSet) (client.TokenSource, error) {
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "auth-token" {
+			slog.Warn("--auth-token is deprecated: tokens on the command line are visible in /proc and shell history; use --auth-token-path or --auth-token-script")
+		}
+	})
+
+	return ResolveTokenSource(*cf.AuthToken, *cf.AuthTokenPath, *cf.AuthTokenScript)
 }
 
 // RequireServerURL returns an error if the URL is empty.
@@ -110,24 +130,22 @@ func RequireServerURL(url string) error {
 	return nil
 }
 
-// RequireAuthToken returns an error if the token is empty.
-func RequireAuthToken(token string) error {
-	if token == "" {
-		return errors.New("auth token is required (use --auth-token, --auth-token-path, NIKS3_AUTH_TOKEN_FILE, or $XDG_CONFIG_HOME/niks3/auth-token)")
-	}
-
-	return nil
-}
-
 //nolint:gosec // G101: help text, not credentials
 const AuthTokenHelp = `  --auth-token string
-        Auth token (default: reads from $XDG_CONFIG_HOME/niks3/auth-token or NIKS3_AUTH_TOKEN_FILE)
-        WARNING: tokens passed on the command line are visible in /proc and shell history;
-        prefer --auth-token-path or NIKS3_AUTH_TOKEN_FILE`
+        DEPRECATED: tokens passed on the command line are visible in /proc and
+        shell history. Use --auth-token-path, --auth-token-script, or
+        NIKS3_AUTH_TOKEN_FILE instead.
+        When unset, falls back to NIKS3_AUTH_TOKEN_FILE or $XDG_CONFIG_HOME/niks3/auth-token`
 
 //nolint:gosec // G101: help text, not credentials
 const AuthTokenPathHelp = `  --auth-token-path string
-        Path to file containing the auth token (preferred over --auth-token)`
+        Path to file containing the auth token (preferred over --auth-token).
+        Re-read periodically so an external refresher can rotate it`
+
+//nolint:gosec // G101: help text, not credentials
+const AuthTokenScriptHelp = `  --auth-token-script string
+        Command that prints {"token":"...","expires_at":"RFC3339"} on stdout.
+        Run on first use and again before expiry. Use for short-lived OIDC tokens`
 
 const TLSHelp = `  --client-cert string
         Client certificate file for mTLS authentication


### PR DESCRIPTION
Long-running uploads (niks3-hook serve) and CI jobs need to refresh
auth tokens that expire mid-run. Today the client resolves auth once
at construction; a GitHub Actions OIDC token (~5 min TTL) goes stale
before a large closure finishes.

Add client.TokenSource, a function resolved per HTTP request:

- StaticToken: fixed string (deprecated --auth-token flag only).
- FileToken: re-reads a file at most once per minute. Used by
  --auth-token-path, NIKS3_AUTH_TOKEN_FILE, and the XDG default.
- ScriptToken: execs a command printing {token, expires_at} JSON,
  caches until 75% of the observed lifetime. New --auth-token-script
  flag on push, gc, and niks3-hook serve.

No auto-retry on 401: the refresh margin covers clock skew, and a
wrong expires_at is a script bug that should be surfaced.

Closes #329.
