### PR TITLE
fix(docker): drop intermediate per-arch image compression

### DIFF
--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -26,6 +26,12 @@ let
     crossPkgs.dockerTools.buildLayeredImage {
       name = niks3-server.pname;
       tag = "${niks3-server.version}-${crossSystem}";
+      # The per-arch tarball is an intermediate that regctl decompresses
+      # immediately. Skip compression: pigz with -p$NIX_BUILD_CORES has
+      # been observed to segfault (likely OOM) on busy CI runners, and
+      # compressing here only to decompress in the next step is wasted CPU.
+      # The final multi-arch image is compressed by regctl on export.
+      compressor = "none";
       contents = [
         (niks3-server.overrideAttrs (old: {
           env = old.env // {


### PR DESCRIPTION
dockerTools.buildLayeredImage produces a per-arch tarball that regctl
immediately decompresses to assemble the multi-arch index. Compressing
that intermediate is wasted CPU, and pigz with -p$NIX_BUILD_CORES has
been observed to segfault (likely OOM) on busy CI runners.

Use compressor = "none" for the per-arch step. The final image regctl
exports is still gzip-compressed; pull behavior is unchanged.
