### PR TITLE
fix(docker): build only native arch on darwin

### DIFF
--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -5,7 +5,7 @@
   imageName ? "${niks3-server.pname}:latest",
 }:
 let
-  supportedPlatforms = {
+  allPlatforms = {
     "x86_64-linux" = {
       GOOS = "linux";
       GOARCH = "amd64";
@@ -15,6 +15,15 @@ let
       GOARCH = "arm64";
     };
   };
+  # On macOS, building the cross-arch Linux image segfaults the Python
+  # layer streamer intermittently. Restrict darwin builds to the native
+  # arch so CI on Apple Silicon still smoke-tests the package; the publish
+  # workflow runs on x86_64-linux and produces the full multi-arch index.
+  supportedPlatforms =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      lib.filterAttrs (n: _: lib.hasPrefix "${pkgs.stdenv.hostPlatform.parsed.cpu.name}-" n) allPlatforms
+    else
+      allPlatforms;
   platforms = lib.mapAttrs (
     crossSystem:
     { GOOS, GOARCH }:


### PR DESCRIPTION
Cross-building the x86_64-linux image on Apple Silicon runs the Python layer streamer under Rosetta, which segfaults intermittently. On darwin, build only the native arch so CI on macOS still smoke-tests the docker package; the publish workflow runs on x86_64-linux and produces the full multi-arch index.