### PR TITLE
ci: exclude bot PRs from auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]


### PR DESCRIPTION
The v1.5.0 changelog had ~50 nixpkgs/dependabot bumps drowning out
the dozen meaningful changes.
