### PR TITLE
feat: mTLS client certificate authentication

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -147,18 +147,22 @@ func (c *Client) SetDebugHTTP(enabled bool) {
 	}
 }
 
-// SetClientTLS configures the HTTP client with a client certificate for mTLS.
-// If caFile is non-empty the server certificate is verified against that CA;
-// otherwise the system certificate pool is used.
+// SetClientTLS configures the HTTP client TLS settings. certFile/keyFile
+// add a client certificate for mTLS; either both or neither must be set.
+// If caFile is non-empty the server certificate is verified against that
+// CA; otherwise the system certificate pool is used.
 func (c *Client) SetClientTLS(certFile, keyFile, caFile string) error {
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
-	if err != nil {
-		return fmt.Errorf("loading client certificate: %w", err)
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
 	}
 
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
+	if certFile != "" || keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return fmt.Errorf("loading client certificate: %w", err)
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	if caFile != "" {

--- a/client/token.go
+++ b/client/token.go
@@ -19,6 +19,12 @@ import (
 // result.
 type TokenSource func(ctx context.Context) (string, error)
 
+// NoToken returns a TokenSource that yields no token. Use when the
+// transport itself carries the credential, e.g. an mTLS client cert.
+func NoToken() TokenSource {
+	return func(context.Context) (string, error) { return "", nil }
+}
+
 // StaticToken returns a TokenSource that always yields tok and never refreshes.
 // An empty tok is valid: it represents anonymous access.
 func StaticToken(tok string) TokenSource {

--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -166,7 +166,7 @@ func runServe() error {
 		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
-	ts, err := cf.TokenSource(fs)
+	ts, err := cf.TokenSource(fs, tf)
 	if err != nil {
 		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -115,7 +115,7 @@ func run() error {
 			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
-		ts, err := cf.TokenSource(pushCmd)
+		ts, err := cf.TokenSource(pushCmd, tf)
 		if err != nil {
 			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
@@ -155,7 +155,7 @@ func run() error {
 			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}
 
-		ts, err := cf.TokenSource(gcCmd)
+		ts, err := cf.TokenSource(gcCmd, tf)
 		if err != nil {
 			return err //nolint:wrapcheck // cmdutil errors are already user-facing
 		}

--- a/cmdutil/cmdutil.go
+++ b/cmdutil/cmdutil.go
@@ -63,7 +63,9 @@ func envAuthTokenPath() string {
 // sources (--auth-token-path, NIKS3_AUTH_TOKEN_FILE, the XDG default) get
 // the same FileToken behavior with periodic re-reads, so an external
 // refresher rotating the file works regardless of how the path was supplied.
-func ResolveTokenSource(flagToken, flagTokenPath, flagTokenScript string) (client.TokenSource, error) {
+// hasMTLS reports whether a client certificate is configured — in which
+// case the transport carries the credential and no bearer token is needed.
+func ResolveTokenSource(flagToken, flagTokenPath, flagTokenScript string, hasMTLS bool) (client.TokenSource, error) {
 	switch {
 	case flagTokenScript != "":
 		return client.ScriptToken(flagTokenScript), nil
@@ -75,6 +77,10 @@ func ResolveTokenSource(flagToken, flagTokenPath, flagTokenScript string) (clien
 
 	if p := envAuthTokenPath(); p != "" {
 		return client.FileToken(p), nil
+	}
+
+	if hasMTLS {
+		return client.NoToken(), nil
 	}
 
 	return nil, errors.New("auth token is required (use --auth-token-path, --auth-token-script, NIKS3_AUTH_TOKEN_FILE, or $XDG_CONFIG_HOME/niks3/auth-token)")
@@ -111,14 +117,17 @@ func AddCommonFlags(fs *flag.FlagSet) CommonFlags {
 // the deprecated --auth-token flag was set explicitly on the command line
 // (as opposed to being filled in from NIKS3_AUTH_TOKEN_FILE or the XDG
 // default). fs must be the FlagSet the flags were registered on.
-func (cf CommonFlags) TokenSource(fs *flag.FlagSet) (client.TokenSource, error) {
+// tf may be the zero value if the command has no TLS flags.
+func (cf CommonFlags) TokenSource(fs *flag.FlagSet, tf TLSFlags) (client.TokenSource, error) {
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "auth-token" {
 			slog.Warn("--auth-token is deprecated: tokens on the command line are visible in /proc and shell history; use --auth-token-path or --auth-token-script")
 		}
 	})
 
-	return ResolveTokenSource(*cf.AuthToken, *cf.AuthTokenPath, *cf.AuthTokenScript)
+	hasMTLS := tf.ClientCert != nil && *tf.ClientCert != ""
+
+	return ResolveTokenSource(*cf.AuthToken, *cf.AuthTokenPath, *cf.AuthTokenScript, hasMTLS)
 }
 
 // RequireServerURL returns an error if the URL is empty.
@@ -176,11 +185,11 @@ func AddTLSFlags(fs *flag.FlagSet) TLSFlags {
 func (tf TLSFlags) Configure(c *client.Client) error {
 	certFile, keyFile, caFile := *tf.ClientCert, *tf.ClientKey, *tf.CACert
 
-	if certFile == "" && keyFile == "" {
+	if certFile == "" && keyFile == "" && caFile == "" {
 		return nil
 	}
 
-	if certFile == "" || keyFile == "" {
+	if (certFile == "") != (keyFile == "") {
 		return errors.New("both --client-cert and --client-key must be provided for mTLS")
 	}
 

--- a/nix/checks/nixos-test-niks3.nix
+++ b/nix/checks/nixos-test-niks3.nix
@@ -91,6 +91,58 @@ testers.nixosTest {
           };
         };
 
+        # mTLS reverse proxy. Trusted, so requests with a verified client
+        # cert skip bearer-token auth. Certs are generated at test runtime
+        # (see testScript) so they never go stale.
+        services.niks3.nginx = {
+          enable = true;
+          domain = "server";
+          enableACME = false;
+          mtls = {
+            enable = true;
+            clientCAFile = "/etc/niks3-test-certs/ca.pem";
+            boundSubjects = [ "CN=niks3 test client" ];
+          };
+        };
+
+        services.nginx.virtualHosts."server" = {
+          sslCertificate = "/etc/niks3-test-certs/server.pem";
+          sslCertificateKey = "/etc/niks3-test-certs/server.key";
+        };
+
+        # Certs are written by the testScript before nginx needs them.
+        systemd.services.nginx = {
+          wants = [ "niks3-test-certs.service" ];
+          after = [ "niks3-test-certs.service" ];
+        };
+
+        systemd.services.niks3-test-certs = {
+          description = "Generate test mTLS certs";
+          before = [ "nginx.service" ];
+          wantedBy = [ "multi-user.target" ];
+          path = [ pkgs.openssl ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            set -euo pipefail
+            mkdir -p /etc/niks3-test-certs
+            cd /etc/niks3-test-certs
+            openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 1 \
+              -keyout ca.key -out ca.pem -subj "/CN=niks3 test CA"
+            openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+              -keyout server.key -out server.csr -subj "/CN=server" -addext "subjectAltName=DNS:server"
+            openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+              -days 1 -copy_extensions copy -out server.pem
+            openssl req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+              -keyout client.key -out client.csr -subj "/CN=niks3 test client"
+            openssl x509 -req -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+              -days 1 -out client.pem
+            chmod 644 *.pem *.key
+          '';
+        };
+
         # Mock OIDC server for testing
         systemd.services.mock-oidc = {
           description = "Mock OIDC server for testing";
@@ -180,6 +232,7 @@ testers.nixosTest {
         environment.etc."niks3-test/symlink-wrapper".source = symlinkWrapper;
 
         networking.firewall.allowedTCPPorts = [
+          443
           5751
           8080
           8081
@@ -242,6 +295,29 @@ testers.nixosTest {
     # Test with invalid auth token file (should fail)
     server.succeed("echo -n 'invalid-token' > /tmp/test-config/invalid-token")
     server.fail(f"NIKS3_SERVER_URL={server_url} NIKS3_AUTH_TOKEN_FILE=/tmp/test-config/invalid-token {niks3_cmd} push {test_path}")
+
+    # ---- mTLS via nginx vhost ----
+    server.wait_for_unit("nginx.service")
+    server.wait_for_open_port(443)
+
+    https_url = "https://server"
+    certs = "/etc/niks3-test-certs"
+    mtls_args = f"--ca-cert {certs}/ca.pem --client-cert {certs}/client.pem --client-key {certs}/client.key"
+
+    # With a verified client cert, no bearer token required.
+    server.succeed(f"{niks3_cmd} push --server-url {https_url} {mtls_args} {test_path}")
+
+    # Without a client cert, anonymous TLS still gets 401 from niks3.
+    server.fail(f"{niks3_cmd} push --server-url {https_url} --ca-cert {certs}/ca.pem {test_path}")
+
+    # Without a cert but with a valid bearer token, still works (mTLS is optional).
+    server.succeed(f"NIKS3_AUTH_TOKEN_FILE=/tmp/test-config/auth-token {niks3_cmd} push --server-url {https_url} --ca-cert {certs}/ca.pem {test_path}")
+
+    # Cert with a non-allowed subject is rejected by --mtls-bound-subject.
+    openssl = "${pkgs.openssl}/bin/openssl"
+    server.succeed(f"cd {certs} && {openssl} req -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -keyout other.key -out other.csr -subj '/CN=other client'")
+    server.succeed(f"cd {certs} && {openssl} x509 -req -in other.csr -CA ca.pem -CAkey ca.key -CAcreateserial -days 1 -out other.pem")
+    server.fail(f"{niks3_cmd} push --server-url {https_url} --ca-cert {certs}/ca.pem --client-cert {certs}/other.pem --client-key {certs}/other.key {test_path}")
 
     # Test pulling from the binary cache using S3 protocol
     server.succeed("mkdir -p /tmp/test-store")

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -299,6 +299,52 @@ in
         default = true;
         description = "Whether to force SSL for the domain.";
       };
+
+      mtls = {
+        enable = lib.mkEnableOption "mTLS client certificate authentication";
+
+        clientCAFile = lib.mkOption {
+          type = lib.types.path;
+          example = "/etc/niks3/client-ca.pem";
+          description = ''
+            CA bundle nginx uses to verify client certificates.
+            Requests presenting a valid cert are accepted by niks3 without
+            a bearer token.
+          '';
+        };
+
+        require = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Require a client certificate (`ssl_verify_client on`). The
+            default `optional` lets clients fall back to bearer-token auth.
+          '';
+        };
+
+        boundSubjects = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "CN=ci-runner,*" ];
+          description = ''
+            Restrict mTLS write auth to certs whose subject DN matches one
+            of these glob patterns (`*` and `?` supported). Empty = any
+            verified cert.
+          '';
+        };
+
+        boundSubjectsRead = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "CN=*,O=Acme" ];
+          description = ''
+            Gate the built-in read proxy behind mTLS: only certs whose
+            subject DN matches one of these globs may read. Empty = the
+            read proxy is public (default). Implies `require = true` so
+            nginx demands a cert on every connection.
+          '';
+        };
+      };
     };
 
     gc = {
@@ -427,6 +473,21 @@ in
               lib.optionalString (cfg.oidc.providers != { }) ''
                 \
                             --oidc-config "${oidcConfigJson}"''
+            }${
+              lib.optionalString cfg.nginx.mtls.enable (
+                ''
+                  \
+                                    --mtls-proxy-header X-SSL-Client-Verify''
+                + lib.concatMapStrings (s: ''
+                  \
+                                    --mtls-bound-subject ${lib.escapeShellArg s}'') cfg.nginx.mtls.boundSubjects
+                +
+                  lib.concatMapStrings
+                    (s: ''
+                      \
+                                        --mtls-bound-subject-read ${lib.escapeShellArg s}'')
+                    cfg.nginx.mtls.boundSubjectsRead
+              )
             }${lib.optionalString cfg.readProxy.enable ''
               \
                           --enable-read-proxy''}${
@@ -540,12 +601,25 @@ in
       virtualHosts.${cfg.nginx.domain} = {
         forceSSL = cfg.nginx.forceSSL;
         enableACME = cfg.nginx.enableACME;
+        extraConfig = lib.optionalString cfg.nginx.mtls.enable ''
+          ssl_client_certificate ${cfg.nginx.mtls.clientCAFile};
+          ssl_verify_client ${
+            if cfg.nginx.mtls.require || cfg.nginx.mtls.boundSubjectsRead != [ ] then "on" else "optional"
+          };
+        '';
         locations."/" = {
           proxyPass = "http://${cfg.httpAddr}";
           extraConfig = ''
             proxy_connect_timeout ${cfg.nginx.proxyTimeout};
             proxy_send_timeout ${cfg.nginx.proxyTimeout};
             proxy_read_timeout ${cfg.nginx.proxyTimeout};
+          ''
+          + lib.optionalString cfg.nginx.mtls.enable ''
+            # niks3 trusts these headers iff --mtls-proxy-header is set.
+            # Always set them (overriding any inbound value) so a client
+            # can't smuggle a fake SUCCESS through a misconfigured proxy.
+            proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+            proxy_set_header X-SSL-Client-Dn $ssl_client_s_dn;
           '';
         };
       };

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -54,6 +54,204 @@ func TestService_AuthMiddleware(t *testing.T) {
 	})
 }
 
+func TestService_AuthMiddleware_MTLSProxyHeader(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+	service.Pool.Close()
+
+	service.APIToken = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	service.MTLSProxyHeader = "X-SSL-Client-Verify"
+
+	// Verified client cert: header set to SUCCESS, no bearer token.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+		},
+	})
+
+	checkUnauthorized := func(t *testing.T, w *httptest.ResponseRecorder) {
+		t.Helper()
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, w.Code)
+		}
+	}
+
+	// Header present but not SUCCESS — e.g. nginx ssl_verify_client optional
+	// passes "NONE" or "FAILED".
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+		header: map[string]string{
+			"X-SSL-Client-Verify": "NONE",
+		},
+	})
+
+	// Header configured but not sent: bearer auth still required.
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+	})
+
+	// Header not configured: SUCCESS is ignored.
+	service.MTLSProxyHeader = ""
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+		},
+	})
+}
+
+func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+	service.Pool.Close()
+
+	service.APIToken = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	service.MTLSProxyHeader = "X-SSL-Client-Verify"
+	service.MTLSSubjectHeader = "X-SSL-Client-Dn"
+	service.MTLSBoundSubjects = []string{"CN=ci-runner,*", "CN=admin"}
+
+	checkUnauthorized := func(t *testing.T, w *httptest.ResponseRecorder) {
+		t.Helper()
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, w.Code)
+		}
+	}
+
+	// Subject matches a glob pattern.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=ci-runner,O=Acme",
+		},
+	})
+
+	// Subject matches an exact pattern.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=admin",
+		},
+	})
+
+	// Subject does not match.
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=untrusted,O=Other",
+		},
+	})
+
+	// Verified cert but missing subject header.
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+		},
+	})
+
+	// Bearer token still works as fallback even when subject doesn't match.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=untrusted",
+			"Authorization":       "Bearer " + service.APIToken,
+		},
+	})
+}
+
+func TestService_ReadAuthMiddleware(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+	service.Pool.Close()
+
+	service.MTLSProxyHeader = "X-SSL-Client-Verify"
+	service.MTLSSubjectHeader = "X-SSL-Client-Dn"
+
+	checkUnauthorized := func(t *testing.T, w *httptest.ResponseRecorder) {
+		t.Helper()
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, w.Code)
+		}
+	}
+
+	// Default: no read bound subjects → public, no headers needed.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.ReadAuthMiddleware(service.HealthCheckHandler),
+	})
+
+	// Read bound subjects set → unauthenticated read rejected.
+	service.MTLSBoundSubjectsRead = []string{"CN=reader-*"}
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.ReadAuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+	})
+
+	// Matching cert subject → allowed.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.ReadAuthMiddleware(service.HealthCheckHandler),
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=reader-1",
+		},
+	})
+
+	// Subject allowed for write but not read.
+	service.MTLSBoundSubjects = []string{"CN=writer"}
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/health",
+		handler:       service.ReadAuthMiddleware(service.HealthCheckHandler),
+		checkResponse: &checkUnauthorized,
+		header: map[string]string{
+			"X-SSL-Client-Verify": "SUCCESS",
+			"X-SSL-Client-Dn":     "CN=writer",
+		},
+	})
+}
+
 func TestService_AuthMiddleware_OIDC(t *testing.T) {
 	t.Parallel()
 

--- a/server/main.go
+++ b/server/main.go
@@ -110,6 +110,11 @@ func parseArgs() (*options, error) {
 		"Restrict mTLS write auth to certs whose subject DN matches this glob; repeat for multiple patterns")
 	flag.Var((*stringSliceFlag)(&opts.MTLSBoundSubjectsRead), "mtls-bound-subject-read",
 		"Gate the read proxy behind mTLS for certs whose subject DN matches this glob; repeat for multiple patterns. Empty = public reads")
+	flag.StringVar(&opts.TLSCert, "tls-cert", getEnvOrDefault("NIKS3_TLS_CERT", ""),
+		"TLS certificate; when set with --tls-key the server terminates TLS itself instead of expecting a reverse proxy")
+	flag.StringVar(&opts.TLSKey, "tls-key", getEnvOrDefault("NIKS3_TLS_KEY", ""), "TLS private key")
+	flag.StringVar(&opts.TLSClientCA, "tls-client-ca", getEnvOrDefault("NIKS3_TLS_CLIENT_CA", ""),
+		"CA bundle for native mTLS client cert verification; subjects checked against --mtls-bound-subject")
 	flag.BoolVar(&opts.EnableReadProxy, "enable-read-proxy",
 		getEnvOrDefault("NIKS3_ENABLE_READ_PROXY", "false") == "true",
 		"Serve cache objects by proxying reads from S3 (for private buckets)")
@@ -188,6 +193,18 @@ func parseArgs() (*options, error) {
 	// API token is always required (for GC and admin operations)
 	if opts.APIToken == "" {
 		return nil, errors.New("missing required flag: --api-token or --api-token-path")
+	}
+
+	if (opts.TLSCert == "") != (opts.TLSKey == "") {
+		return nil, errors.New("--tls-cert and --tls-key must be set together")
+	}
+
+	if opts.TLSClientCA != "" && opts.TLSCert == "" {
+		return nil, errors.New("--tls-client-ca requires --tls-cert and --tls-key")
+	}
+
+	if opts.TLSClientCA != "" && opts.MTLSProxyHeader != "" {
+		return nil, errors.New("--tls-client-ca and --mtls-proxy-header are mutually exclusive")
 	}
 
 	if len(opts.APIToken) < minAPITokenLength {

--- a/server/main.go
+++ b/server/main.go
@@ -101,6 +101,15 @@ func parseArgs() (*options, error) {
 		"Maximum concurrent S3 operations (default: 100)")
 	flag.Float64Var(&opts.S3RateLimit, "s3-rate-limit", getEnvOrDefaultFloat("NIKS3_S3_RATE_LIMIT", 0),
 		"Initial S3 requests per second (0 = unlimited, adapts on 429)")
+	flag.StringVar(&opts.MTLSProxyHeader, "mtls-proxy-header", getEnvOrDefault("NIKS3_MTLS_PROXY_HEADER", ""),
+		"Header set to SUCCESS by the reverse proxy after mTLS client cert verification (e.g. X-SSL-Client-Verify); requests with it skip bearer auth")
+	flag.StringVar(&opts.MTLSSubjectHeader, "mtls-subject-header", getEnvOrDefault("NIKS3_MTLS_SUBJECT_HEADER", "X-SSL-Client-Dn"),
+		"Header carrying the verified cert's subject DN, used with --mtls-bound-subject")
+
+	flag.Var((*stringSliceFlag)(&opts.MTLSBoundSubjects), "mtls-bound-subject",
+		"Restrict mTLS write auth to certs whose subject DN matches this glob; repeat for multiple patterns")
+	flag.Var((*stringSliceFlag)(&opts.MTLSBoundSubjectsRead), "mtls-bound-subject-read",
+		"Gate the read proxy behind mTLS for certs whose subject DN matches this glob; repeat for multiple patterns. Empty = public reads")
 	flag.BoolVar(&opts.EnableReadProxy, "enable-read-proxy",
 		getEnvOrDefault("NIKS3_ENABLE_READ_PROXY", "false") == "true",
 		"Serve cache objects by proxying reads from S3 (for private buckets)")

--- a/server/mtls.go
+++ b/server/mtls.go
@@ -1,11 +1,44 @@
 package server
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/Mic92/niks3/server/oidc"
 )
+
+// serverTLSConfig builds a tls.Config for ListenAndServeTLS. If clientCA
+// is set, the server requests and verifies client certs against it (native
+// mTLS).
+func serverTLSConfig(clientCA string) (*tls.Config, error) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if clientCA == "" {
+		return cfg, nil
+	}
+
+	pem, err := os.ReadFile(clientCA)
+	if err != nil {
+		return nil, fmt.Errorf("reading client CA: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("parsing client CA %q: no PEM certificates found", clientCA)
+	}
+
+	cfg.ClientCAs = pool
+	// VerifyClientCertIfGiven: anonymous TLS is allowed so bearer-token
+	// auth and public reads still work; AuthMiddleware/ReadAuthMiddleware
+	// decide what an unauthenticated request may do.
+	cfg.ClientAuth = tls.VerifyClientCertIfGiven
+
+	return cfg, nil
+}
 
 // ReadAuthMiddleware gates the read proxy behind mTLS when
 // MTLSBoundSubjectsRead is non-empty. Reads are otherwise public: Nix
@@ -34,14 +67,11 @@ func (s *Service) mtlsAuthenticated(r *http.Request) bool {
 	return s.mtlsCheck(r, s.MTLSBoundSubjects)
 }
 
-// mtlsCheck verifies the proxy headers and, if boundSubjects is non-empty,
-// matches the cert subject DN against them.
+// mtlsCheck verifies the client cert (native or proxied) and, if
+// boundSubjects is non-empty, matches the subject DN against them.
 func (s *Service) mtlsCheck(r *http.Request, boundSubjects []string) bool {
-	if s.MTLSProxyHeader == "" {
-		return false
-	}
-
-	if r.Header.Get(s.MTLSProxyHeader) != "SUCCESS" {
+	subject, ok := s.mtlsSubject(r)
+	if !ok {
 		return false
 	}
 
@@ -51,10 +81,8 @@ func (s *Service) mtlsCheck(r *http.Request, boundSubjects []string) bool {
 		return true
 	}
 
-	subject := r.Header.Get(s.MTLSSubjectHeader)
 	if subject == "" {
-		slog.Warn("mTLS auth: bound subjects configured but subject header missing or empty",
-			"header", s.MTLSSubjectHeader)
+		slog.Warn("mTLS auth: bound subjects configured but subject DN unavailable")
 
 		return false
 	}
@@ -70,4 +98,23 @@ func (s *Service) mtlsCheck(r *http.Request, boundSubjects []string) bool {
 	slog.Warn("mTLS auth: subject not in bound subjects", "subject", subject)
 
 	return false
+}
+
+// mtlsSubject returns the verified client cert's subject DN, and whether a
+// cert was verified at all. Native mTLS reads r.TLS directly; otherwise
+// the configured proxy headers are trusted.
+func (s *Service) mtlsSubject(r *http.Request) (string, bool) {
+	if s.NativeMTLS {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			return "", false
+		}
+
+		return r.TLS.PeerCertificates[0].Subject.String(), true
+	}
+
+	if s.MTLSProxyHeader == "" || r.Header.Get(s.MTLSProxyHeader) != "SUCCESS" {
+		return "", false
+	}
+
+	return r.Header.Get(s.MTLSSubjectHeader), true
 }

--- a/server/mtls.go
+++ b/server/mtls.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/Mic92/niks3/server/oidc"
+)
+
+// ReadAuthMiddleware gates the read proxy behind mTLS when
+// MTLSBoundSubjectsRead is non-empty. Reads are otherwise public: Nix
+// substituters present no credentials and the cache contents are
+// integrity-signed.
+func (s *Service) ReadAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	if len(s.MTLSBoundSubjectsRead) == 0 {
+		return next
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !s.mtlsCheck(r, s.MTLSBoundSubjectsRead) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}
+
+// mtlsAuthenticated reports whether the request carries proxy headers
+// proving a verified mTLS client cert that is allowed by MTLSBoundSubjects.
+// Used for the write API.
+func (s *Service) mtlsAuthenticated(r *http.Request) bool {
+	return s.mtlsCheck(r, s.MTLSBoundSubjects)
+}
+
+// mtlsCheck verifies the proxy headers and, if boundSubjects is non-empty,
+// matches the cert subject DN against them.
+func (s *Service) mtlsCheck(r *http.Request, boundSubjects []string) bool {
+	if s.MTLSProxyHeader == "" {
+		return false
+	}
+
+	if r.Header.Get(s.MTLSProxyHeader) != "SUCCESS" {
+		return false
+	}
+
+	if len(boundSubjects) == 0 {
+		slog.Debug("mTLS auth: any verified cert accepted")
+
+		return true
+	}
+
+	subject := r.Header.Get(s.MTLSSubjectHeader)
+	if subject == "" {
+		slog.Warn("mTLS auth: bound subjects configured but subject header missing or empty",
+			"header", s.MTLSSubjectHeader)
+
+		return false
+	}
+
+	for _, pattern := range boundSubjects {
+		if oidc.GlobMatch(pattern, subject) {
+			slog.Debug("mTLS auth: subject matched", "subject", subject, "pattern", pattern)
+
+			return true
+		}
+	}
+
+	slog.Warn("mTLS auth: subject not in bound subjects", "subject", subject)
+
+	return false
+}

--- a/server/mtls.go
+++ b/server/mtls.go
@@ -15,7 +15,11 @@ import (
 // is set, the server requests and verifies client certs against it (native
 // mTLS).
 func serverTLSConfig(clientCA string) (*tls.Config, error) {
-	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		// ListenAndServeTLS only auto-enables HTTP/2 when TLSConfig is nil.
+		NextProtos: []string{"h2", "http/1.1"},
+	}
 
 	if clientCA == "" {
 		return cfg, nil
@@ -45,11 +49,15 @@ func serverTLSConfig(clientCA string) (*tls.Config, error) {
 // substituters present no credentials and the cache contents are
 // integrity-signed.
 func (s *Service) ReadAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	if len(s.MTLSBoundSubjectsRead) == 0 {
-		return next
-	}
-
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Checked per-request, not at registration: the bound subject list
+		// may not be set yet when the mux is built (e.g. in tests).
+		if len(s.MTLSBoundSubjectsRead) == 0 {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
 		if !s.mtlsCheck(r, s.MTLSBoundSubjectsRead) {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 

--- a/server/mtls_test.go
+++ b/server/mtls_test.go
@@ -1,0 +1,75 @@
+package server_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestService_NativeMTLS exercises the direct-TLS auth path that reads
+// r.TLS.PeerCertificates instead of trusting proxy headers.
+func TestService_NativeMTLS(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+	service.Pool.Close()
+
+	service.APIToken = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	service.NativeMTLS = true
+	service.MTLSBoundSubjects = []string{"CN=writer"}
+	service.MTLSBoundSubjectsRead = []string{"CN=reader"}
+
+	mkReq := func(cn string) *http.Request {
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health", nil)
+		if cn != "" {
+			r.TLS = &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{
+					{Subject: pkix.Name{CommonName: cn}},
+				},
+			}
+		} else {
+			r.TLS = &tls.ConnectionState{} // anonymous TLS
+		}
+
+		return r
+	}
+
+	check := func(t *testing.T, h http.HandlerFunc, cn string, wantCode int) {
+		t.Helper()
+
+		w := httptest.NewRecorder()
+		h(w, mkReq(cn))
+
+		if w.Code != wantCode {
+			t.Errorf("cn=%q: got %d, want %d", cn, w.Code, wantCode)
+		}
+	}
+
+	write := service.AuthMiddleware(service.HealthCheckHandler)
+	read := service.ReadAuthMiddleware(service.HealthCheckHandler)
+
+	check(t, write, "writer", http.StatusOK)
+	check(t, write, "reader", http.StatusUnauthorized)
+	check(t, write, "", http.StatusUnauthorized)
+
+	check(t, read, "reader", http.StatusOK)
+	check(t, read, "writer", http.StatusUnauthorized)
+	check(t, read, "", http.StatusUnauthorized)
+
+	// Proxy headers ignored under native mTLS.
+	r := mkReq("")
+	r.Header.Set("X-Ssl-Client-Verify", "SUCCESS")
+	r.Header.Set("X-Ssl-Client-Dn", "CN=writer")
+
+	w := httptest.NewRecorder()
+	write(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("native mTLS must ignore proxy headers, got %d", w.Code)
+	}
+}

--- a/server/oidc/claims.go
+++ b/server/oidc/claims.go
@@ -25,7 +25,7 @@ func validateBoundClaims(claims map[string]any, boundClaims map[string][]string)
 		matched := false
 		for _, v := range values {
 			for _, pattern := range allowedPatterns {
-				if matchGlob(pattern, v) {
+				if GlobMatch(pattern, v) {
 					matched = true
 					break
 				}
@@ -54,7 +54,7 @@ func validateBoundSubject(claims map[string]any, boundSubject []string) error {
 	}
 
 	for _, pattern := range boundSubject {
-		if matchGlob(pattern, sub) {
+		if GlobMatch(pattern, sub) {
 			return nil
 		}
 	}
@@ -112,14 +112,8 @@ func normalizeToStringSlice(value any) []string {
 	}
 }
 
-// matchGlob performs glob pattern matching.
-// Supports * (matches any sequence of characters) and ? (matches any single character).
-func matchGlob(pattern, value string) bool {
-	return globMatch(pattern, value)
-}
-
-// globMatch implements glob matching with * and ? wildcards.
-func globMatch(pattern, str string) bool {
+// GlobMatch implements glob matching with * and ? wildcards.
+func GlobMatch(pattern, str string) bool {
 	// Empty pattern only matches empty string
 	if pattern == "" {
 		return str == ""

--- a/server/oidc/oidc_test.go
+++ b/server/oidc/oidc_test.go
@@ -48,8 +48,8 @@ func TestGlobMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.pattern+"_"+tt.value, func(t *testing.T) {
-			if got := globMatch(tt.pattern, tt.value); got != tt.want {
-				t.Errorf("globMatch(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
+			if got := GlobMatch(tt.pattern, tt.value); got != tt.want {
+				t.Errorf("GlobMatch(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
 			}
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,17 @@ type options struct {
 	// these globs may read. Empty = read proxy is public (default).
 	MTLSBoundSubjectsRead []string
 
+	// TLSCert/TLSKey, when both set, make the server terminate TLS itself
+	// instead of expecting a reverse proxy.
+	TLSCert string
+	TLSKey  string
+
+	// TLSClientCA, when set with TLSCert/TLSKey, enables native mTLS:
+	// the server requests and verifies client certs against this CA bundle.
+	// The cert subject is checked against MTLSBoundSubjects directly —
+	// no proxy headers involved.
+	TLSClientCA string
+
 	Debug bool
 }
 
@@ -80,7 +91,13 @@ type Service struct {
 	MTLSSubjectHeader     string
 	MTLSBoundSubjects     []string
 	MTLSBoundSubjectsRead []string
-	GCTasks               *GCTaskStore
+
+	// NativeMTLS is set when the server terminates TLS itself with a
+	// client CA — mtlsCheck reads r.TLS.PeerCertificates directly
+	// instead of trusting proxy headers.
+	NativeMTLS bool
+
+	GCTasks *GCTaskStore
 }
 
 // Close closes the database connection pool.
@@ -311,6 +328,24 @@ func runServer(opts *options) error {
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
+	}
+
+	if opts.TLSCert != "" {
+		tlsCfg, err := serverTLSConfig(opts.TLSClientCA)
+		if err != nil {
+			return err
+		}
+
+		server.TLSConfig = tlsCfg
+		service.NativeMTLS = opts.TLSClientCA != ""
+
+		slog.Info("Starting HTTPS server", "address", opts.HTTPAddr, "mtls", service.NativeMTLS)
+
+		if err = server.ListenAndServeTLS(opts.TLSCert, opts.TLSKey); err != nil {
+			return fmt.Errorf("failed to start server: %w", err)
+		}
+
+		return nil
 	}
 
 	slog.Info("Starting HTTP server", "address", opts.HTTPAddr)

--- a/server/server.go
+++ b/server/server.go
@@ -41,21 +41,46 @@ type options struct {
 	OIDCConfigPath  string
 	EnableReadProxy bool
 
+	// MTLSProxyHeader, when set, names a header the reverse proxy sets to
+	// "SUCCESS" after verifying a client certificate (e.g. nginx's
+	// $ssl_client_verify). Requests carrying it are accepted without a
+	// bearer token. ONLY enable behind a proxy that overrides the header
+	// on every request — including failed/anonymous ones.
+	MTLSProxyHeader string
+
+	// MTLSSubjectHeader names the header carrying the verified cert's
+	// subject DN (e.g. nginx's $ssl_client_s_dn). Used with
+	// MTLSBoundSubjects.
+	MTLSSubjectHeader string
+
+	// MTLSBoundSubjects restricts mTLS auth to certs whose subject DN
+	// matches one of these glob patterns. Empty = any verified cert.
+	MTLSBoundSubjects []string
+
+	// MTLSBoundSubjectsRead, when non-empty, gates the read proxy behind
+	// mTLS: only clients presenting a cert whose subject DN matches one of
+	// these globs may read. Empty = read proxy is public (default).
+	MTLSBoundSubjectsRead []string
+
 	Debug bool
 }
 
 type Service struct {
-	Pool            *pgxpool.Pool
-	MinioClient     *minio.Client
-	Bucket          string
-	S3Concurrency   int
-	S3RateLimiter   *ratelimit.AdaptiveRateLimiter
-	APIToken        string
-	SigningKeys     []*signing.Key
-	CacheURL        string
-	OIDCValidator   *oidc.Validator
-	EnableReadProxy bool
-	GCTasks         *GCTaskStore
+	Pool                  *pgxpool.Pool
+	MinioClient           *minio.Client
+	Bucket                string
+	S3Concurrency         int
+	S3RateLimiter         *ratelimit.AdaptiveRateLimiter
+	APIToken              string
+	SigningKeys           []*signing.Key
+	CacheURL              string
+	OIDCValidator         *oidc.Validator
+	EnableReadProxy       bool
+	MTLSProxyHeader       string
+	MTLSSubjectHeader     string
+	MTLSBoundSubjects     []string
+	MTLSBoundSubjectsRead []string
+	GCTasks               *GCTaskStore
 }
 
 // Close closes the database connection pool.
@@ -69,6 +94,15 @@ const (
 
 func (s *Service) AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// mTLS via reverse proxy. The proxy is responsible for overriding
+		// these headers on every request; we only trust them because the
+		// operator opted in.
+		if s.mtlsAuthenticated(r) {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -126,7 +160,8 @@ func (s *Service) logAuthFailure(token string, oidcErr *oidc.ValidationError) {
 
 	if oidcErr != nil {
 		// Log OIDC-specific failure details
-		slog.Warn("Authentication failed",
+		slog.Warn(
+			"Authentication failed",
 			"token_preview", tokenPreview,
 			"token_length", len(token),
 			"oidc_error", oidcErr.Reason,
@@ -139,14 +174,16 @@ func (s *Service) logAuthFailure(token string, oidcErr *oidc.ValidationError) {
 		}
 	} else if s.OIDCValidator != nil {
 		// OIDC configured but we didn't get a ValidationError (shouldn't happen normally)
-		slog.Warn("Authentication failed",
+		slog.Warn(
+			"Authentication failed",
 			"token_preview", tokenPreview,
 			"token_length", len(token),
 			"reason", "token did not match OIDC or static API token",
 		)
 	} else {
 		// No OIDC configured, just static token mismatch
-		slog.Warn("Authentication failed",
+		slog.Warn(
+			"Authentication failed",
 			"token_preview", tokenPreview,
 			"token_length", len(token),
 			"reason", "static API token mismatch",
@@ -181,14 +218,18 @@ func runServer(opts *options) error {
 	}
 
 	service := &Service{
-		Pool:          pool,
-		MinioClient:   minioClient,
-		Bucket:        opts.S3Bucket,
-		S3Concurrency: opts.S3Concurrency,
-		S3RateLimiter: ratelimit.NewAdaptiveRateLimiter(opts.S3RateLimit, "s3"),
-		APIToken:      opts.APIToken,
-		CacheURL:      opts.CacheURL,
-		GCTasks:       NewGCTaskStore(),
+		Pool:                  pool,
+		MinioClient:           minioClient,
+		Bucket:                opts.S3Bucket,
+		S3Concurrency:         opts.S3Concurrency,
+		S3RateLimiter:         ratelimit.NewAdaptiveRateLimiter(opts.S3RateLimit, "s3"),
+		APIToken:              opts.APIToken,
+		MTLSProxyHeader:       opts.MTLSProxyHeader,
+		MTLSSubjectHeader:     opts.MTLSSubjectHeader,
+		MTLSBoundSubjects:     opts.MTLSBoundSubjects,
+		MTLSBoundSubjectsRead: opts.MTLSBoundSubjectsRead,
+		CacheURL:              opts.CacheURL,
+		GCTasks:               NewGCTaskStore(),
 	}
 
 	// Initialize OIDC validator if configured
@@ -254,7 +295,7 @@ func runServer(opts *options) error {
 		service.EnableReadProxy = true
 		// Register without method prefix to avoid ServeMux conflicts with
 		// auto-generated HEAD routes. The handler rejects non-GET/HEAD itself.
-		mux.HandleFunc("/{path...}", service.ReadProxyHandler)
+		mux.HandleFunc("/{path...}", service.ReadAuthMiddleware(service.ReadProxyHandler))
 		slog.Info("Read proxy enabled — serving cache objects from S3")
 	} else {
 		mux.HandleFunc("GET /", service.RootRedirectHandler)


### PR DESCRIPTION
#325 added mTLS transport but the server still required a bearer token. Make a verified client cert a first-class credential.

**Server:**
- `--tls-cert`/`--tls-key` for native TLS termination, `--tls-client-ca` for native mTLS (reads `r.TLS.PeerCertificates` directly — no header trust)
- `--mtls-proxy-header` trusts the reverse proxy's verify header (e.g. nginx `$ssl_client_verify`) when behind a proxy
- `--mtls-bound-subject` restricts write access to matching cert subject DNs (globs)
- `--mtls-bound-subject-read` independently gates the read proxy (empty = public reads)

**Client:**
- `--auth-token-*` optional when `--client-cert` is set
- `--ca-cert` alone now configures TLS (was a silent no-op)

**NixOS module:**
- `services.niks3.nginx.mtls.{enable,clientCAFile,require,boundSubjects,boundSubjectsRead}` wires up nginx `ssl_verify_client` and the proxy headers
- NixOS test exercises cert auth, anonymous rejection, token fallback, and bound-subject mismatch

Documented at https://github.com/Mic92/niks3/wiki/mTLS

⚠️ `--mtls-proxy-header` must only be enabled behind a proxy that overrides the headers on every request — otherwise clients can fake `SUCCESS`. Native TLS (`--tls-client-ca`) avoids this.