### PR TITLE
server: support uploading filenames containing ..

### DIFF
--- a/server/upload_key.go
+++ b/server/upload_key.go
@@ -16,7 +16,8 @@ func IsValidUploadKey(key, objType string) bool {
 		return false
 	}
 
-	if strings.HasPrefix(key, "/") || strings.Contains(key, "..") {
+	if strings.HasPrefix(key, "/") || strings.HasPrefix(key, "../") ||
+		strings.HasSuffix(key, "/..") || strings.Contains(key, "/../") {
 		return false
 	}
 

--- a/server/upload_key_test.go
+++ b/server/upload_key_test.go
@@ -26,6 +26,7 @@ func TestIsValidUploadKey(t *testing.T) {
 		{"nar plain", "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar", "nar", true},
 		{"listing", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.ls", "listing", true},
 		{"build log", "log/abcd1234-hello-1.0.drv", "build_log", true},
+		{"build log home-manager file", "log/abcd1234-hm_..zlogout.drv", "build_log", true},
 		{"realisation", "realisations/sha256:abc123!out.doi", "realisation", true},
 
 		// Server-owned files: never client-writable


### PR DESCRIPTION
Fixes the following error:

`pushing paths: creating pending closures: creating pending closure: server returned 400: invalid object key "log/ggi5q4gfdn7ihjjmgfqb4hzbdw9sz7h4-hm_..zlogin.drv" for type "build_log"`

Marking as draft as untested