### PR TITLE
server: accept +, ?, = in upload key validation

### DIFF
--- a/server/proxy.go
+++ b/server/proxy.go
@@ -157,11 +157,12 @@ var (
 	// ls: {32-char nix-base32 hash}.ls
 	lsRe = regexp.MustCompile(`^[` + nixBase32Alphabet + `]{32}\.ls$`)
 
-	// log: log/{name}.drv — name can contain alphanumerics, hyphens, dots, underscores
-	logRe = regexp.MustCompile(`^log/[a-zA-Z0-9._-]+\.drv$`)
+	// log: log/{name}.drv — name alphabet matches nix's nameRegexStr
+	// in src/libstore/path.cc: [A-Za-z0-9+\-._?=]
+	logRe = regexp.MustCompile(`^log/[a-zA-Z0-9+._?=-]+\.drv$`)
 
 	// realisations: realisations/{hash-algo}:{hex}!{output}.doi
-	realisationsRe = regexp.MustCompile(`^realisations/[a-z0-9]+:[a-zA-Z0-9+/=]+![a-zA-Z0-9_-]+\.doi$`)
+	realisationsRe = regexp.MustCompile(`^realisations/[a-z0-9]+:[a-zA-Z0-9+/=]+![a-zA-Z0-9+._?=-]+\.doi$`)
 )
 
 // IsValidCachePath checks whether a path matches a known Nix binary cache object pattern.
@@ -176,8 +177,10 @@ func IsValidCachePath(path string) bool {
 		return false
 	}
 
-	// Reject path traversal
-	if strings.Contains(path, "..") {
+	// Reject ".." path segments. Don't use a plain Contains check here:
+	// store-path names can legitimately contain ".." (e.g. hm_..zlogout.drv).
+	if strings.HasPrefix(path, "../") || strings.HasSuffix(path, "/..") ||
+		strings.Contains(path, "/../") || path == ".." {
 		return false
 	}
 

--- a/server/upload_key_test.go
+++ b/server/upload_key_test.go
@@ -27,7 +27,11 @@ func TestIsValidUploadKey(t *testing.T) {
 		{"listing", "26xbg1ndr7hbcncrlf9nhx5is2b25d13.ls", "listing", true},
 		{"build log", "log/abcd1234-hello-1.0.drv", "build_log", true},
 		{"build log home-manager file", "log/abcd1234-hm_..zlogout.drv", "build_log", true},
+		{"build log plus in name", "log/z96xgwn1b618qdygp6j59ij07wjhvdl0-events_history_sdk-1.1.3.post19+t202603130851.tar.gz.drv", "build_log", true},
+		{"build log question mark", "log/abcd1234-foo?bar.drv", "build_log", true},
+		{"build log equals", "log/abcd1234-foo=bar.drv", "build_log", true},
 		{"realisation", "realisations/sha256:abc123!out.doi", "realisation", true},
+		{"realisation plus in output", "realisations/sha256:abc123!out+dev.doi", "realisation", true},
 
 		// Server-owned files: never client-writable
 		{"nix-cache-info", "nix-cache-info", "narinfo", false},


### PR DESCRIPTION

The key regexes added in #373 were stricter than nix's own store-path
name alphabet ([A-Za-z0-9+-._?=], see nameRegexStr in
src/libstore/path.cc). Derivations with '+' in the name (common with
setuptools_scm / PEP 440 local versions) got rejected with a 400 on
build_log upload.

Fixes #389
