### PR TITLE
client: scale multipart part size with NAR size

### DIFF
--- a/client/export_test.go
+++ b/client/export_test.go
@@ -12,6 +12,12 @@ var ParsePathInfoJSON = parsePathInfoJSON //nolint:gochecknoglobals // test-only
 // ShellSplit re-exports shellSplit for the external test package.
 var ShellSplit = shellSplit //nolint:gochecknoglobals // test-only re-export
 
+// PartSizeForNAR re-exports partSizeForNAR for the external test package.
+var PartSizeForNAR = partSizeForNAR //nolint:gochecknoglobals // test-only re-export
+
+// MultipartPartSize re-exports the default part size for tests.
+const MultipartPartSize = multipartPartSize
+
 // ScriptTokenWithClock builds a ScriptToken with an injected clock for tests.
 var ScriptTokenWithClock = scriptToken //nolint:gochecknoglobals // test-only re-export
 

--- a/client/multipart.go
+++ b/client/multipart.go
@@ -14,8 +14,34 @@ import (
 )
 
 const (
-	multipartPartSize = 10 * 1024 * 1024 // 10MB parts for balance between overhead and throughput
+	multipartPartSize = 10 * 1024 * 1024       // default/minimum part size
+	maxPartSize       = 5 * 1024 * 1024 * 1024 // S3 max part size
+	// S3 allows at most 10000 parts. Aim for 9000: zstd can emit a bit more
+	// than the input on incompressible data, and rounding to a 16 MiB step
+	// gives no slack right at a boundary. The headroom only costs a
+	// slightly bigger part size.
+	targetMaxParts = 9000
 )
+
+// partSizeForNAR returns a part size that keeps the compressed upload under
+// S3's 10000-part limit. We don't know the compressed size up front, but the
+// uncompressed NAR size is a safe upper bound. Rounded up to 16 MiB steps
+// (same as minio-go), clamped to the default 10 MiB and S3's 5 GiB max.
+func partSizeForNAR(narSize uint64) int {
+	const step = 16 << 20
+
+	size := (narSize + targetMaxParts - 1) / targetMaxParts
+	if size <= multipartPartSize {
+		return multipartPartSize
+	}
+
+	size = (size + step - 1) / step * step
+	if size > maxPartSize {
+		return maxPartSize
+	}
+
+	return int(size)
+}
 
 // formatBytes formats bytes in human-readable form (KB/MB/GB).
 func formatBytes(bytes uint64) string {
@@ -33,13 +59,27 @@ func formatBytes(bytes uint64) string {
 	return fmt.Sprintf("%.1f%cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }
 
-// uploadBufferPool pools 10MB buffers for multipart uploads to reduce memory allocations.
+// uploadBufferPool pools default-sized part buffers to reduce allocations.
+// Larger NARs get a one-off buffer (rare, not worth pooling).
 var uploadBufferPool = sync.Pool{ //nolint:gochecknoglobals // sync.Pool should be global
 	New: func() any {
 		buf := make([]byte, multipartPartSize)
 
 		return &buf
 	},
+}
+
+func getPartBuffer(partSize int) ([]byte, func()) {
+	if partSize > multipartPartSize {
+		return make([]byte, partSize), func() {}
+	}
+
+	ptr, ok := uploadBufferPool.Get().(*[]byte)
+	if !ok {
+		return make([]byte, multipartPartSize), func() {}
+	}
+
+	return *ptr, func() { uploadBufferPool.Put(ptr) }
 }
 
 // MultipartUploadInfo contains multipart upload information.
@@ -171,20 +211,13 @@ func (c *Client) CompleteMultipartUpload(ctx context.Context, objectKey, uploadI
 }
 
 // uploadMultipart uploads a stream in parts using presigned URLs (sequential).
-func (c *Client) uploadMultipart(ctx context.Context, r io.Reader, multipartInfo *MultipartUploadInfo, objectKey string) error {
-	slog.Debug("Uploading", "object_key", objectKey)
+func (c *Client) uploadMultipart(ctx context.Context, r io.Reader, multipartInfo *MultipartUploadInfo, objectKey string, partSize int) error {
+	slog.Debug("Uploading", "object_key", objectKey, "part_size", partSize)
 
 	var completedParts []CompletedPart
 
-	// Get buffer from pool
-	bufferPtr, ok := uploadBufferPool.Get().(*[]byte)
-	if !ok {
-		return errors.New("failed to get buffer from pool")
-	}
-
-	defer uploadBufferPool.Put(bufferPtr)
-
-	buffer := *bufferPtr
+	buffer, release := getPartBuffer(partSize)
+	defer release()
 
 	partNumber := 1
 	partURLs := multipartInfo.PartURLs
@@ -210,7 +243,7 @@ func (c *Client) uploadMultipart(ctx context.Context, r io.Reader, multipartInfo
 			slog.Info("Received additional part URLs", "count", len(newPartURLs), "total_parts", len(partURLs))
 		}
 
-		// Read up to multipartPartSize for this part
+		// Read up to partSize for this part
 		n, readErr := io.ReadFull(r, buffer)
 		if errors.Is(readErr, io.EOF) {
 			// Done reading

--- a/client/multipart_size_test.go
+++ b/client/multipart_size_test.go
@@ -1,0 +1,56 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+func TestPartSizeForNAR(t *testing.T) {
+	t.Parallel()
+
+	const (
+		mib     = 1 << 20
+		gib     = 1 << 30
+		tib     = 1 << 40
+		minPart = client.MultipartPartSize
+	)
+
+	tests := []struct {
+		name    string
+		narSize uint64
+		want    int
+	}{
+		{"zero stays at minimum", 0, minPart},
+		{"small stays at minimum", 1 * mib, minPart},
+		// 80 GiB / 9000 ~= 9.1 MiB -> rounds up to 10 MiB, exactly the minimum.
+		{"80 GiB fits at minimum", 80 * gib, minPart},
+		// 115 GiB / 9000 ~= 13.1 MiB -> 16 MiB step. This is the size from issue #387.
+		{"115 GiB needs larger parts", 115 * gib, 16 * mib},
+		// 1 TiB / 9000 ~= 116.5 MiB -> 128 MiB
+		{"1 TiB", 1 * tib, 128 * mib},
+		// 5 TiB (S3 max object) / 9000 ~= 582.6 MiB -> 592 MiB
+		{"5 TiB S3 max object", 5 * tib, 592 * mib},
+		// Absurd: capped at S3 max part size
+		{"capped at 5 GiB", 100 * tib, 5 * gib},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := client.PartSizeForNAR(tc.narSize)
+			if got != tc.want {
+				t.Errorf("PartSizeForNAR(%d) = %d, want %d", tc.narSize, got, tc.want)
+			}
+
+			if got < minPart {
+				t.Errorf("PartSizeForNAR(%d) = %d, below minimum %d", tc.narSize, got, minPart)
+			}
+
+			if got > 5*gib {
+				t.Errorf("PartSizeForNAR(%d) = %d, above S3 max part size", tc.narSize, got)
+			}
+		})
+	}
+}

--- a/client/nar_upload.go
+++ b/client/nar_upload.go
@@ -90,7 +90,7 @@ func (c *Client) CompressAndUploadNAR(ctx context.Context, storePath string, nar
 		listingChan <- listing
 	}()
 
-	err := c.uploadMultipart(ctx, pr, multipartInfo, objectKey)
+	err := c.uploadMultipart(ctx, pr, multipartInfo, objectKey, partSizeForNAR(narSize))
 	// If upload failed, signal compressor to stop and wait for it to exit
 	if err != nil {
 		_ = pw.CloseWithError(err)


### PR DESCRIPTION

Part size was hardcoded to 10 MiB, so uploads topped out at 100 GiB
(S3's 10000-part limit). Anything bigger died at part 10001.

We already know the uncompressed NAR size up front and zstd output
can't be meaningfully larger, so derive the part size from that:
aim for ~9000 parts, round up to a 16 MiB step (same as minio-go),
cap at S3's 5 GiB part max. Small NARs keep the pooled 10 MiB
buffer; big ones get a one-off allocation.

Fixes #387
