### PR TITLE
fix: upload small NARs with a single PUT to avoid API throttling

### DIFF
--- a/client/nar_task.go
+++ b/client/nar_task.go
@@ -17,7 +17,7 @@ func (c *Client) uploadNARWithListing(
 		return fmt.Errorf("missing PathInfo for NAR %s", narTask.key)
 	}
 
-	listing, err := c.CompressAndUploadNAR(ctx, pathInfo.Path, pathInfo.NarSize, narTask.obj.MultipartInfo, narTask.key)
+	listing, err := c.CompressAndUploadNAR(ctx, pathInfo.Path, pathInfo.NarSize, narTask.obj, narTask.key)
 	if err != nil {
 		return fmt.Errorf("uploading NAR %s: %w", narTask.key, err)
 	}

--- a/client/nar_upload.go
+++ b/client/nar_upload.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,16 +28,65 @@ var zstdEncoderPool = sync.Pool{ //nolint:gochecknoglobals // sync.Pool should b
 	},
 }
 
-// CompressAndUploadNAR compresses a NAR and uploads it using multipart upload.
+// compressAndSimpleUploadNAR uploads a small NAR with a single presigned PUT.
+// The compressed NAR is stored as opaque bytes with no Content-Encoding (like multipart part upload);
+// nix-daemon decompresses it per the narinfo Compression field.
+func (c *Client) compressAndSimpleUploadNAR(ctx context.Context, storePath, presignedURL, objectKey string) (*NarListing, error) {
+	encoder, ok := zstdEncoderPool.Get().(*zstd.Encoder)
+	if !ok {
+		return nil, errors.New("failed to get zstd encoder from pool")
+	}
+	defer zstdEncoderPool.Put(encoder)
+
+	var buf bytes.Buffer
+
+	encoder.Reset(&buf)
+
+	listing, err := DumpPathWithListing(encoder, storePath)
+	if err != nil {
+		return nil, fmt.Errorf("serializing NAR: %w", err)
+	}
+
+	if err := encoder.Close(); err != nil {
+		return nil, fmt.Errorf("closing zstd encoder: %w", err)
+	}
+
+	if err := c.UploadBytesToPresignedURLWithHeaders(ctx, presignedURL, buf.Bytes(), nil); err != nil {
+		return nil, fmt.Errorf("uploading NAR %s: %w", objectKey, err)
+	}
+
+	return listing, nil
+}
+
+// CompressAndUploadNAR compresses a NAR and uploads it.
+// Small NARs are sent with a single presigned PUT, larger ones via multipart upload.
 // It also generates a directory listing during serialization.
-func (c *Client) CompressAndUploadNAR(ctx context.Context, storePath string, narSize uint64, multipartInfo *MultipartUploadInfo, objectKey string) (*NarListing, error) {
+func (c *Client) CompressAndUploadNAR(ctx context.Context, storePath string, narSize uint64, obj PendingObject, objectKey string) (*NarListing, error) {
 	name := filepath.Base(storePath)
 	slog.Info(fmt.Sprintf("Uploading %s (%s)", name, formatBytes(narSize)))
 
-	if multipartInfo == nil {
-		return nil, errors.New("NAR files require multipart upload info")
+	var (
+		listing *NarListing
+		err     error
+	)
+
+	if obj.MultipartInfo != nil {
+		listing, err = c.compressAndMultipartUploadNAR(ctx, storePath, narSize, obj.MultipartInfo, objectKey)
+	} else {
+		listing, err = c.compressAndSimpleUploadNAR(ctx, storePath, obj.PresignedURL, objectKey)
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("Uploaded NAR", "object_key", objectKey)
+
+	return listing, nil
+}
+
+// compressAndMultipartUploadNAR streams a compressed NAR through a multipart upload.
+func (c *Client) compressAndMultipartUploadNAR(ctx context.Context, storePath string, narSize uint64, multipartInfo *MultipartUploadInfo, objectKey string) (*NarListing, error) {
 	// Create a pipe for streaming: NAR serialization -> zstd compression -> hash/size tracking
 	pr, pw := io.Pipe()
 
@@ -105,9 +155,5 @@ func (c *Client) CompressAndUploadNAR(ctx context.Context, storePath string, nar
 		return nil, compressErr
 	}
 
-	listing := <-listingChan
-
-	slog.Debug("Uploaded NAR", "object_key", objectKey)
-
-	return listing, nil
+	return <-listingChan, nil
 }

--- a/server/pending_closure.go
+++ b/server/pending_closure.go
@@ -287,9 +287,12 @@ func (s *Service) createPendingObjects(
 				narSize = *obj.NarSize
 			}
 
-			narTasks = append(narTasks, narTask{key: pendingObject.Key, narSize: narSize})
+			// Small NARs fall through to a presigned PUT like the other small objects.
+			if !useSimpleUpload(narSize) {
+				narTasks = append(narTasks, narTask{key: pendingObject.Key, narSize: narSize})
 
-			continue
+				continue
+			}
 		}
 
 		po, err := s.makePresignedURL(ctx, pendingObject.Key, obj.Type)

--- a/server/pending_multipart.go
+++ b/server/pending_multipart.go
@@ -14,6 +14,14 @@ const (
 	multipartPartSize = 10 * 1024 * 1024 // 10MB parts
 )
 
+// useSimpleUpload reports whether a NAR of the given uncompressed size should
+// be uploaded with a single presigned PUT instead of a multipart upload.
+// NARs that fit into one part gain nothing from multipart but cost extra S3
+// API calls. Size 0 (unknown) uses multipart.
+func useSimpleUpload(narSize uint64) bool {
+	return narSize > 0 && narSize <= multipartPartSize
+}
+
 type MultipartUploadInfo struct {
 	UploadID string   `json:"upload_id"`
 	PartURLs []string `json:"part_urls"`

--- a/server/throttle_test.go
+++ b/server/throttle_test.go
@@ -126,7 +126,7 @@ func TestCompleteMultipartUploadHandler_RateLimitTriggersThrottle(t *testing.T) 
 		"closure": narinfoKey,
 		"objects": []map[string]any{
 			{"key": narinfoKey, "type": "narinfo", "refs": []string{narKey}},
-			{"key": narKey, "type": "nar", "refs": []string{}, "nar_size": 10 * 1024 * 1024}, // 10MB to trigger multipart
+			{"key": narKey, "type": "nar", "refs": []string{}, "nar_size": 20 * 1024 * 1024}, // above simple-upload threshold to trigger multipart
 		},
 	})
 	ok(t, err)

--- a/server/uploads_test.go
+++ b/server/uploads_test.go
@@ -528,3 +528,55 @@ func TestCompleteMultipartUnregistered(t *testing.T) {
 		checkResponse: &checkNotFound,
 	})
 }
+
+// TestCreatePendingClosure_SmallNARUsesSimplePUT ensures NARs at or below the
+// multipart part size get a single presigned PUT URL instead of a multipart
+// upload, which saves S3 API calls (relevant for providers with strict rate
+// limits, e.g. Backblaze B2).
+func TestCreatePendingClosure_SmallNARUsesSimplePUT(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	closureHash := "dddddddddddddddddddddddddddddd01"
+	narinfoKey := closureHash + ".narinfo"
+	smallNarKey := narKeyFor(closureHash)
+	largeNarKey := narKeyFor("dddddddddddddddddddddddddddddd02")
+
+	body, err := json.Marshal(map[string]any{
+		"closure": narinfoKey,
+		"objects": []map[string]any{
+			{"key": narinfoKey, "type": "narinfo", "refs": []string{smallNarKey, largeNarKey}},
+			{"key": smallNarKey, "type": "nar", "refs": []string{}, "nar_size": 1024},
+			{"key": largeNarKey, "type": "nar", "refs": []string{}, "nar_size": 20 * 1024 * 1024},
+		},
+	})
+	ok(t, err)
+
+	rr := testRequest(t, &TestRequest{
+		method:  "POST",
+		path:    "/api/pending_closures",
+		body:    body,
+		handler: service.CreatePendingClosureHandler,
+	})
+
+	var resp server.PendingClosureResponse
+
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	ok(t, err)
+
+	small := resp.PendingObjects[smallNarKey]
+	if small.MultipartInfo != nil {
+		t.Errorf("small NAR should not use multipart upload")
+	}
+
+	if small.PresignedURL == "" {
+		t.Errorf("small NAR should have a presigned URL")
+	}
+
+	large := resp.PendingObjects[largeNarKey]
+	if large.MultipartInfo == nil {
+		t.Errorf("large NAR should use multipart upload")
+	}
+}


### PR DESCRIPTION
Thanks for making niks3!

I migrated from attic to niks3 over the weekend and have been using OIDC push from gha to B2 with about 180 jobs (my concurrency limit is 40 i think?) per run

One problem I noticed is that, when there are multiple runners pushing paths, I would get 429 error from b2 API (their limit is 500 rps) because currently no matter how big the NARs are it would be using multi part upload (at least 3x API call comparing with simple put, 1x for setup, 1 call per part upload, and 1x for closing multi part upload)

Here I'd check the NAR size and use a single PUT for small NARs (<= 10M) instead of sending everything over multi part

LLM usage disclosure: Opus 4.8