### PR TITLE
Fix the architecture of niks3 binary in the docker image

### DIFF
--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -54,7 +54,10 @@ let
             fi
           '';
         }))
-        (import ./niks3.nix { inherit pkgs lib; })
+        (import ./niks3.nix {
+          pkgs = crossPkgs;
+          inherit lib;
+        })
       ]
       ++ (with crossPkgs.pkgsStatic; [
         busybox


### PR DESCRIPTION
In aarch64 image, the niks3 binary was x86_64-linux.