### PR TITLE
hook: apply sqlite pragmas via DSN to fix SQLITE_BUSY

### DIFF
--- a/hook/queue.go
+++ b/hook/queue.go
@@ -24,26 +24,17 @@ func OpenQueue(dbPath string) (*Queue, error) {
 		return nil, fmt.Errorf("creating database directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	// Pragmas go in the DSN so they apply to every pooled connection; a one-off
+	// ExecContext only configures the single connection serving that call,
+	// leaving other connections without busy_timeout and failing with SQLITE_BUSY.
+	dsn := "file:" + dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
 	ctx := context.Background()
-
-	// WAL mode for better concurrent read/write performance.
-	if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
-		_ = db.Close()
-
-		return nil, fmt.Errorf("setting WAL mode: %w", err)
-	}
-
-	// Busy timeout so concurrent access retries instead of failing immediately.
-	if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout=5000"); err != nil {
-		_ = db.Close()
-
-		return nil, fmt.Errorf("setting busy timeout: %w", err)
-	}
 
 	// Create the queue table.
 	if _, err := db.ExecContext(ctx, `

--- a/hook/queue_test.go
+++ b/hook/queue_test.go
@@ -1,8 +1,10 @@
 package hook_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/Mic92/niks3/hook"
@@ -158,5 +160,54 @@ func TestQueueFetchRemoveLifecycle(t *testing.T) {
 
 	if count != 0 {
 		t.Errorf("expected 0 after remove, got %d", count)
+	}
+}
+
+// TestQueueConcurrentWriters reproduces the SQLITE_BUSY failures from issue #409;
+// it only passes when busy_timeout is applied to every pooled connection.
+func TestQueueConcurrentWriters(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+
+	const writers = 8
+
+	const perWriter = 50
+
+	var wg sync.WaitGroup
+
+	errs := make(chan error, writers)
+
+	for w := range writers {
+		wg.Add(1)
+
+		go func(w int) {
+			defer wg.Done()
+
+			for i := range perWriter {
+				p := fmt.Sprintf("/nix/store/path-%d-%d", w, i)
+				if err := q.Enqueue([]string{p}); err != nil {
+					errs <- err
+
+					return
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("Enqueue under concurrency: %v", err)
+	}
+
+	count, err := q.Count()
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+
+	if count != writers*perWriter {
+		t.Errorf("expected %d, got %d", writers*perWriter, count)
 	}
 }


### PR DESCRIPTION

journal_mode=WAL and busy_timeout were set with a one-off ExecContext
after sql.Open. That only configures the single pooled connection serving
that call. Concurrent Enqueue (socket handler) and FetchBatch/Remove
(worker) open additional pooled connections without busy_timeout, so they
error immediately with SQLITE_BUSY instead of retrying.

Move both pragmas into the DSN so every connection in the pool inherits
them. Closes #409.
