### PR TITLE
feat(s3): allow selecting bucket addressing style

### DIFF
--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -160,6 +160,23 @@ in
         description = "Whether to use SSL for S3 connections.";
       };
 
+      bucketLookup = lib.mkOption {
+        type = lib.types.enum [
+          "auto"
+          "dns"
+          "path"
+        ];
+        default = "auto";
+        description = ''
+          S3 bucket addressing style. "auto" lets the client pick (virtual-host
+          for AWS/GCS/Aliyun, path-style otherwise). Set "dns" to force
+          virtual-host style (<bucket>.<endpoint>), required by providers that
+          reject path-style requests (e.g. CoreWeave). Set "path" to force
+          path-style.
+        '';
+        example = "dns";
+      };
+
       accessKeyFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -456,7 +473,8 @@ in
             --http-addr "${cfg.httpAddr}" \
             --s3-endpoint "${cfg.s3.endpoint}" \
             --s3-bucket "${cfg.s3.bucket}" \
-            --s3-use-ssl="${if cfg.s3.useSSL then "true" else "false"}"${
+            --s3-use-ssl="${if cfg.s3.useSSL then "true" else "false"}" \
+            --s3-bucket-lookup "${cfg.s3.bucketLookup}"${
               lib.optionalString (cfg.s3.region != "") ''
                 \
                            --s3-region "${cfg.s3.region}"''

--- a/server/main.go
+++ b/server/main.go
@@ -8,7 +8,26 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	minio "github.com/minio/minio-go/v7"
 )
+
+// parseBucketLookup maps a string ("auto", "dns", "path") to a
+// minio.BucketLookupType. "dns" forces virtual-host-style addressing
+// (<bucket>.<endpoint>), required by some S3-compatible providers
+// (e.g. CoreWeave) that reject path-style requests.
+func parseBucketLookup(value string) (minio.BucketLookupType, error) {
+	switch strings.ToLower(value) {
+	case "", "auto":
+		return minio.BucketLookupAuto, nil
+	case "dns":
+		return minio.BucketLookupDNS, nil
+	case "path":
+		return minio.BucketLookupPath, nil
+	default:
+		return minio.BucketLookupAuto, fmt.Errorf("invalid bucket lookup %q: want auto, dns, or path", value)
+	}
+}
 
 func getEnvOrDefault(key, defaultValue string) string {
 	if value, ok := os.LookupEnv(key); ok {
@@ -75,6 +94,7 @@ func parseArgs() (*options, error) {
 	s3AccessKeyPath := ""
 	s3SecretKeyPath := ""
 	apiTokenPath := ""
+	s3BucketLookup := ""
 
 	flag.StringVar(&opts.DBConnectionString, "db", getEnvOrDefault("NIKS3_DB", ""),
 		"Postgres connection string, see https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters")
@@ -87,6 +107,8 @@ func parseArgs() (*options, error) {
 		"Use IAM credentials from the environment (IRSA, EC2 instance profile, etc.) instead of static keys")
 	flag.StringVar(&opts.S3Bucket, "s3-bucket", getEnvOrDefault("NIKS3_S3_BUCKET", ""), "S3 bucket name")
 	flag.StringVar(&opts.S3Region, "s3-region", getEnvOrDefault("NIKS3_S3_REGION", ""), "S3 region override (e.g., us-east-1, auto)")
+	flag.StringVar(&s3BucketLookup, "s3-bucket-lookup", getEnvOrDefault("NIKS3_S3_BUCKET_LOOKUP", "auto"),
+		"S3 bucket addressing style: auto (default), dns (virtual-host, e.g. CoreWeave), or path")
 	flag.StringVar(&s3AccessKeyPath, "s3-access-key-path", getEnvOrDefault("NIKS3_S3_ACCESS_KEY_PATH", ""),
 		"Path to file containing S3 access key")
 	flag.StringVar(&s3SecretKeyPath, "s3-secret-key-path", getEnvOrDefault("NIKS3_S3_SECRET_KEY_PATH", ""),
@@ -146,6 +168,10 @@ func parseArgs() (*options, error) {
 	}
 
 	var err error
+
+	if opts.S3BucketLookup, err = parseBucketLookup(s3BucketLookup); err != nil {
+		return nil, err
+	}
 
 	var secret string
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,15 +25,16 @@ type options struct {
 	DBConnectionString string
 	HTTPAddr           string
 
-	S3Endpoint    string
-	S3AccessKey   string
-	S3SecretKey   string
-	S3UseSSL      bool
-	S3UseIAM      bool
-	S3Bucket      string
-	S3Region      string
-	S3Concurrency int
-	S3RateLimit   float64
+	S3Endpoint     string
+	S3AccessKey    string
+	S3SecretKey    string
+	S3UseSSL       bool
+	S3UseIAM       bool
+	S3Bucket       string
+	S3Region       string
+	S3BucketLookup minio.BucketLookupType
+	S3Concurrency  int
+	S3RateLimit    float64
 
 	APIToken string
 
@@ -189,9 +190,10 @@ func runServer(opts *options) error {
 	}
 
 	minioClient, err := minio.New(opts.S3Endpoint, &minio.Options{
-		Creds:  creds,
-		Secure: opts.S3UseSSL,
-		Region: opts.S3Region,
+		Creds:        creds,
+		Secure:       opts.S3UseSSL,
+		Region:       opts.S3Region,
+		BucketLookup: opts.S3BucketLookup,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create minio s3 client: %w", err)


### PR DESCRIPTION
This solves an issue where some S3 providers don't allow PathStyle adressing and the minio-go library can't detect it. The container crashloops because of the 400 error replied.
This PR allows to select the bucket addressing style via arg and env-var, tested with said S3 provider.
Code was entirely generated by LLM, let me know if I need to cleanup some stuff, thank you!
cc @gaetanlepage