### PR TITLE
chore(gitignore): adopt the official Nix template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
+# Local development data (e.g. PRJ_DATA_DIR / PGDATA from .envrc)
 .data
+
+# Build outputs
 /niks3
 /niks3.test
-/result
 /server/server.test
-
 /client/target
+
+# Ignore build outputs from performing a nix-build or `nix build` command
+result
+result-*
+
+# Ignore automatically generated direnv output
+.direnv
+
+# Ignore NixOS interactive test driver history
+**/.nixos-test-history


### PR DESCRIPTION
Adopt `gh repo gitignore view Nix` so locally generated Nix artifacts stop polluting `git status`.

The `.direnv/` directory is created on every shell entry by the `.envrc`'s `use flake`.
Without an ignore rule it shows up as untracked on every status check.
That risks accidental staging.

The template also broadens `/result` to `result` and adds `result-*`,
so out-of-root and named symlinks are covered too.
It adds `**/.nixos-test-history` for the NixOS test driver as well.

The existing project-specific entries are kept and grouped under a comment.
That keeps the file self-explanatory.
