### PR TITLE
ci: skip niks3-docker on Darwin

### DIFF
--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,14 +1,21 @@
 {
   pkgs,
+  lib ? pkgs.lib,
 }:
-rec {
-  rustfs = pkgs.callPackage ./rustfs.nix { };
-  niks3 = pkgs.callPackage ./niks3.nix { };
-  niks3-server = pkgs.callPackage ./niks3-server.nix { };
-  niks3-hook = pkgs.callPackage ./niks3-hook.nix { };
-  niks3-tests = pkgs.callPackage ./niks3-tests.nix { inherit (pkgs) go; };
-  niks3-docker = pkgs.callPackage ./niks3-docker.nix { inherit niks3-server; };
-  mock-oidc-server = pkgs.callPackage ./mock-oidc-server.nix { };
-  benchmark-closure = pkgs.callPackage ../benchmark/benchmark-closure.nix { };
-  default = niks3;
+let
+  packages = rec {
+    rustfs = pkgs.callPackage ./rustfs.nix { };
+    niks3 = pkgs.callPackage ./niks3.nix { };
+    niks3-server = pkgs.callPackage ./niks3-server.nix { };
+    niks3-hook = pkgs.callPackage ./niks3-hook.nix { };
+    niks3-tests = pkgs.callPackage ./niks3-tests.nix { inherit (pkgs) go; };
+    mock-oidc-server = pkgs.callPackage ./mock-oidc-server.nix { };
+    benchmark-closure = pkgs.callPackage ../benchmark/benchmark-closure.nix { };
+    default = niks3;
+  };
+in
+packages
+# Skip the docker image on Darwin: https://github.com/NixOS/nixpkgs/pull/536230
+// lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isDarwin) {
+  niks3-docker = pkgs.callPackage ./niks3-docker.nix { inherit (packages) niks3-server; };
 }

--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -15,15 +15,6 @@ let
       GOARCH = "arm64";
     };
   };
-  # On macOS, building the cross-arch Linux image segfaults the Python
-  # layer streamer intermittently. Restrict darwin builds to the native
-  # arch so CI on Apple Silicon still smoke-tests the package; the publish
-  # workflow runs on x86_64-linux and produces the full multi-arch index.
-  supportedPlatforms =
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      lib.filterAttrs (n: _: lib.hasPrefix "${pkgs.stdenv.hostPlatform.parsed.cpu.name}-" n) allPlatforms
-    else
-      allPlatforms;
   platforms = lib.mapAttrs (
     crossSystem:
     { GOOS, GOARCH }:
@@ -71,7 +62,7 @@ let
         };
       };
     }
-  ) supportedPlatforms;
+  ) allPlatforms;
 in
 pkgs.stdenvNoCC.mkDerivation {
   name = "${niks3-server.pname}-docker";


### PR DESCRIPTION
Cross-building the aarch64-linux docker image on a Darwin builder hits a dockerTools bug: streamLayeredImage's wrapper gets a host-arch (Linux) shebang and segfaults the builder when run on macOS.

Tracked in https://github.com/NixOS/nixpkgs/pull/536230