### PR TITLE
server: abort redundant multipart uploads when a NAR completes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -206,6 +206,18 @@ func deferCloseBody(resp *http.Response) {
 	}
 }
 
+// HTTPStatusError carries the status code of an unexpected HTTP response so
+// callers can branch on it (e.g. a 404 mid-multipart means a peer already
+// finished the NAR and the upload was aborted).
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("server returned %d: %s", e.StatusCode, e.Body)
+}
+
 func checkResponse(resp *http.Response, acceptedStatuses ...int) error {
 	if slices.Contains(acceptedStatuses, resp.StatusCode) {
 		return nil
@@ -213,7 +225,7 @@ func checkResponse(resp *http.Response, acceptedStatuses ...int) error {
 
 	body, _ := io.ReadAll(resp.Body)
 
-	return fmt.Errorf("server returned %d: %s", resp.StatusCode, body)
+	return &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 }
 
 func (c *Client) putBytes(ctx context.Context, url string, data []byte) (*http.Response, error) {

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/Mic92/niks3/ratelimit"
 )
@@ -45,4 +48,22 @@ func NewTestClientWithToken(httpClient *http.Client, retry RetryConfig, ts Token
 // NewTestClientWithStoreDir creates a Client with only storeDir set, for path resolution tests.
 func NewTestClientWithStoreDir(storeDir string) *Client {
 	return &Client{storeDir: storeDir}
+}
+
+// NewTestClientForServer returns a Client whose server requests target serverURL.
+func NewTestClientForServer(serverURL string) (*Client, error) {
+	baseURL, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // test helper
+	}
+
+	c := NewTestClient(&http.Client{}, DefaultRetryConfig())
+	c.baseURL = baseURL
+
+	return c, nil
+}
+
+// UploadMultipart re-exports uploadMultipart for the external test package.
+func (c *Client) UploadMultipart(ctx context.Context, r io.Reader, info *MultipartUploadInfo, objectKey string, partSize int) error {
+	return c.uploadMultipart(ctx, r, info, objectKey, partSize)
 }

--- a/client/multipart.go
+++ b/client/multipart.go
@@ -82,6 +82,55 @@ func getPartBuffer(partSize int) ([]byte, func()) {
 	return *ptr, func() { uploadBufferPool.Put(ptr) }
 }
 
+// ErrUploadSuperseded means a concurrent closure already finished the same NAR
+// and our upload was aborted server-side. The blob exists, so callers skip it.
+var ErrUploadSuperseded = errors.New("multipart upload superseded by a concurrent upload")
+
+// supersededByPeer reports whether a 404 from the upload means the NAR is
+// already present. A 404 is ambiguous (peer abort vs expired upload), so we
+// confirm the object exists in S3 before skipping to avoid losing data.
+func (c *Client) supersededByPeer(ctx context.Context, objectKey string, err error) bool {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
+		return false
+	}
+
+	exists, existsErr := c.ObjectExists(ctx, objectKey)
+	if existsErr != nil {
+		slog.Warn("Failed to confirm object after upload 404", "object_key", objectKey, "error", existsErr)
+
+		return false
+	}
+
+	return exists
+}
+
+// ObjectExists reports whether objectKey is already present in S3.
+func (c *Client) ObjectExists(ctx context.Context, objectKey string) (bool, error) {
+	reqURL := c.baseURL.JoinPath("api/objects", objectKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL.String(), nil)
+	if err != nil {
+		return false, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.DoServerRequest(ctx, req)
+	if err != nil {
+		return false, fmt.Errorf("sending request: %w", err)
+	}
+
+	defer deferCloseBody(resp)
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, &HTTPStatusError{StatusCode: resp.StatusCode}
+	}
+}
+
 // MultipartUploadInfo contains multipart upload information.
 type MultipartUploadInfo struct {
 	UploadID string   `json:"upload_id"`
@@ -263,6 +312,10 @@ func (c *Client) uploadMultipart(ctx context.Context, r io.Reader, multipartInfo
 
 		etag, err := c.uploadPart(ctx, partURL, partData)
 		if err != nil {
+			if c.supersededByPeer(ctx, objectKey, err) {
+				return ErrUploadSuperseded
+			}
+
 			return fmt.Errorf("uploading part %d: %w", partNumber, err)
 		}
 
@@ -288,6 +341,10 @@ func (c *Client) uploadMultipart(ctx context.Context, r io.Reader, multipartInfo
 	// Complete the multipart upload
 	err := c.CompleteMultipartUpload(ctx, objectKey, multipartInfo.UploadID, completedParts)
 	if err != nil {
+		if c.supersededByPeer(ctx, objectKey, err) {
+			return ErrUploadSuperseded
+		}
+
 		return fmt.Errorf("completing multipart upload: %w", err)
 	}
 

--- a/client/multipart_superseded_test.go
+++ b/client/multipart_superseded_test.go
@@ -1,0 +1,79 @@
+package client_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+// TestUploadMultipart_SupersededByPeer verifies that when a part upload fails
+// with 404 (a peer aborted our multipart upload), the client only skips the NAR
+// after confirming the object exists. A 404 plus a missing object is a real
+// error, guarding against silent data loss.
+func TestUploadMultipart_SupersededByPeer(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		objectExists bool
+		wantErr      error
+	}{
+		{name: "exists", objectExists: true, wantErr: client.ErrUploadSuperseded},
+		{name: "missing", objectExists: false, wantErr: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPut:
+					// The presigned part upload: peer already aborted it.
+					http.Error(w, "no such upload", http.StatusNotFound)
+				case r.Method == http.MethodHead && strings.HasPrefix(r.URL.Path, "/api/objects/"):
+					if tc.objectExists {
+						w.WriteHeader(http.StatusNoContent)
+					} else {
+						w.WriteHeader(http.StatusNotFound)
+					}
+				default:
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+				}
+			}))
+			defer srv.Close()
+
+			c, err := client.NewTestClientForServer(srv.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			info := &client.MultipartUploadInfo{
+				UploadID: "upload-1",
+				PartURLs: []string{srv.URL + "/part/1"},
+			}
+
+			err = c.UploadMultipart(context.Background(), bytes.NewReader([]byte("payload")),
+				info, "nar/abc.nar.zst", client.MultipartPartSize)
+
+			switch {
+			case tc.wantErr != nil:
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+			default:
+				if err == nil {
+					t.Fatal("expected a real error when the object is absent, got nil")
+				}
+
+				if errors.Is(err, client.ErrUploadSuperseded) {
+					t.Fatalf("must not skip when object is absent: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/client/nar_task.go
+++ b/client/nar_task.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 )
@@ -19,6 +20,13 @@ func (c *Client) uploadNARWithListing(
 
 	listing, err := c.CompressAndUploadNAR(ctx, pathInfo.Path, pathInfo.NarSize, narTask.obj, narTask.key)
 	if err != nil {
+		if errors.Is(err, ErrUploadSuperseded) {
+			// A peer already uploaded this NAR (and its listing); nothing to do.
+			slog.Debug("Skipping NAR superseded by concurrent upload", "key", narTask.key)
+
+			return nil
+		}
+
 		return fmt.Errorf("uploading NAR %s: %w", narTask.key, err)
 	}
 

--- a/server/pg/query.sql
+++ b/server/pg/query.sql
@@ -114,6 +114,13 @@ WHERE pc.started_at < timezone('UTC', now()) - interval '1 second' * $1::int;
 DELETE FROM multipart_uploads
 WHERE upload_id = $1;
 
+-- name: GetRedundantMultipartUploads :many
+-- Upload IDs other pending_closures opened for object_key, used to abort
+-- duplicates once one upload of the NAR completes.
+SELECT upload_id
+FROM multipart_uploads
+WHERE object_key = $1 AND upload_id <> $2;
+
 -- name: GetMultipartUpload :one
 SELECT pending_closure_id, object_key, upload_id
 FROM multipart_uploads

--- a/server/pg/query.sql.go
+++ b/server/pg/query.sql.go
@@ -346,6 +346,39 @@ func (q *Queries) GetPin(ctx context.Context, name string) (Pin, error) {
 	return i, err
 }
 
+const getRedundantMultipartUploads = `-- name: GetRedundantMultipartUploads :many
+SELECT upload_id
+FROM multipart_uploads
+WHERE object_key = $1 AND upload_id <> $2
+`
+
+type GetRedundantMultipartUploadsParams struct {
+	ObjectKey string `json:"object_key"`
+	UploadID  string `json:"upload_id"`
+}
+
+// Upload IDs other pending_closures opened for object_key, used to abort
+// duplicates once one upload of the NAR completes.
+func (q *Queries) GetRedundantMultipartUploads(ctx context.Context, arg GetRedundantMultipartUploadsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, getRedundantMultipartUploads, arg.ObjectKey, arg.UploadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var upload_id string
+		if err := rows.Scan(&upload_id); err != nil {
+			return nil, err
+		}
+		items = append(items, upload_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const insertMultipartUpload = `-- name: InsertMultipartUpload :exec
 INSERT INTO multipart_uploads (pending_closure_id, object_key, upload_id)
 VALUES ($1, $2, $3)

--- a/server/redundant_multipart_test.go
+++ b/server/redundant_multipart_test.go
@@ -1,0 +1,76 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/server"
+	"github.com/minio/minio-go/v7"
+)
+
+// TestRedundantMultipartUpload drives two pending closures that share the same
+// NAR through the multipart path. Completing one upload must abort the other's
+// in-flight upload.
+func TestRedundantMultipartUpload(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	// Unique nix-base32 hashes (no e/o/t/u) to avoid collisions under -parallel.
+	sharedNarKey := narKeyFor("gggggggggggggggggggggggggggggg01")
+	firstNarinfo := "gggggggggggggggggggggggggggggg10.narinfo"
+	secondNarinfo := "gggggggggggggggggggggggggggggg20.narinfo"
+
+	postSharedClosure := func(narinfoKey string) server.PendingObject {
+		t.Helper()
+
+		body, err := json.Marshal(map[string]any{
+			"closure": narinfoKey,
+			"objects": []map[string]any{
+				{"key": narinfoKey, "type": "narinfo", "refs": []string{sharedNarKey}},
+				{"key": sharedNarKey, "type": "nar", "refs": []string{}, "nar_size": 100 * 1024 * 1024},
+			},
+		})
+		ok(t, err)
+
+		rr := testRequest(t, &TestRequest{
+			method:  "POST",
+			path:    "/api/pending_closures",
+			body:    body,
+			handler: service.CreatePendingClosureHandler,
+		})
+
+		var resp server.PendingClosureResponse
+		ok(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+		nar := resp.PendingObjects[sharedNarKey]
+		if nar.MultipartInfo == nil || nar.MultipartInfo.UploadID == "" {
+			t.Fatalf("expected multipart upload for shared NAR")
+		}
+
+		return nar
+	}
+
+	coreClient := minio.Core{Client: service.MinioClient}
+
+	winner := postSharedClosure(firstNarinfo)
+	loser := postSharedClosure(secondNarinfo)
+	loserUploadID := loser.MultipartInfo.UploadID
+
+	// Loser's upload is live until the winner completes.
+	_, err := coreClient.ListObjectParts(ctx, service.Bucket, sharedNarKey, loserUploadID, 0, 10)
+	ok(t, err)
+
+	// Completing the winner registers the NAR and aborts the loser's upload.
+	handleMultipartUpload(ctx, t, sharedNarKey, winner, service)
+
+	if _, err := coreClient.ListObjectParts(ctx, service.Bucket, sharedNarKey, loserUploadID, 0, 10); err == nil {
+		t.Error("expected loser's multipart upload to be aborted, but it is still live")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -271,6 +271,7 @@ func runServer(opts *options) error {
 	mux.HandleFunc("POST /api/pending_closures/{id}/complete", service.AuthMiddleware(service.CommitPendingClosureHandler))
 	mux.HandleFunc("POST /api/multipart/complete", service.AuthMiddleware(service.CompleteMultipartUploadHandler))
 	mux.HandleFunc("POST /api/multipart/request-parts", service.AuthMiddleware(service.RequestMorePartsHandler))
+	mux.HandleFunc("HEAD /api/objects/{key...}", service.AuthMiddleware(service.ObjectExistsHandler))
 	mux.HandleFunc("GET /api/closures/{key}", service.AuthMiddleware(service.GetClosureHandler))
 	mux.HandleFunc("DELETE /api/closures", service.AuthMiddleware(service.CleanupClosuresOlder))
 	mux.HandleFunc("GET /api/gc/status", service.AuthMiddleware(service.GCStatusHandler))

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -378,9 +379,85 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		slog.Error("Failed to delete multipart upload tracking row", "error", err, "upload_id", req.UploadID)
 	}
 
+	// The NAR now exists in S3; abort any duplicate uploads peers opened for
+	// the same key instead of waiting for garbage collection.
+	s.abortRedundantMultipartUploads(r.Context(), req.ObjectKey, req.UploadID)
+
 	slog.Info("Completed multipart upload", "object_key", req.ObjectKey, "upload_id", req.UploadID, "parts", len(req.Parts))
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// ObjectExistsHandler handles HEAD /api/objects/{key...}: 204 if objectKey is
+// in S3, 404 otherwise. Lets a client confirm a NAR is present before skipping
+// an upload a peer aborted.
+func (s *Service) ObjectExistsHandler(w http.ResponseWriter, r *http.Request) {
+	objectKey := r.PathValue("key")
+	if objectKey == "" {
+		http.Error(w, "missing object key", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.S3RateLimiter.Wait(r.Context()); err != nil {
+		http.Error(w, "rate limiter context canceled", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	_, err := s.MinioClient.StatObject(r.Context(), s.Bucket, objectKey, minio.StatObjectOptions{})
+	if err != nil {
+		if isRateLimitError(err) {
+			s.S3RateLimiter.RecordThrottle()
+		}
+
+		if minio.ToErrorResponse(err).Code == minio.NoSuchKey {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		slog.Error("Failed to stat object", "error", err, "object_key", objectKey)
+		http.Error(w, "failed to stat object", http.StatusInternalServerError)
+
+		return
+	}
+
+	s.S3RateLimiter.RecordSuccess()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// abortRedundantMultipartUploads aborts multipart uploads other pending_closures
+// opened for objectKey, excluding keepUploadID. Best-effort: the winning upload
+// already succeeded and stragglers are also reaped by cleanupPendingClosures.
+func (s *Service) abortRedundantMultipartUploads(ctx context.Context, objectKey, keepUploadID string) {
+	queries := pg.New(s.Pool)
+
+	uploadIDs, err := queries.GetRedundantMultipartUploads(ctx, pg.GetRedundantMultipartUploadsParams{
+		ObjectKey: objectKey,
+		UploadID:  keepUploadID,
+	})
+	if err != nil {
+		slog.Error("Failed to list redundant multipart uploads", "error", err, "object_key", objectKey)
+
+		return
+	}
+
+	coreClient := minio.Core{Client: s.MinioClient}
+
+	for _, uploadID := range uploadIDs {
+		if err := coreClient.AbortMultipartUpload(ctx, s.Bucket, objectKey, uploadID); err != nil {
+			if minio.ToErrorResponse(err).Code != minio.NoSuchUpload {
+				slog.Warn("Failed to abort redundant multipart upload",
+					"object_key", objectKey, "upload_id", uploadID, "error", err)
+			}
+		}
+
+		if err := queries.DeleteMultipartUpload(ctx, uploadID); err != nil {
+			slog.Error("Failed to delete redundant multipart upload row",
+				"error", err, "upload_id", uploadID)
+		}
+	}
 }
 
 type signNarinfosRequest struct {


### PR DESCRIPTION
Parallel CI workflows pushing the same closure each open their own multipart upload for the shared NAR (pending_closures are not deduplicated). Only the winner completes; the rest lingered until garbage collection, bloating the S3 backend's multipart metadata.

Abort the other pending_closures' in-flight uploads for that key once the NAR completes, instead of waiting for the GC pass.

Aborted clients see a 404 on the next part or on completion. Since a 404 is ambiguous (peer abort vs expired upload), the client confirms the object via HEAD /api/objects/{key} before skipping, so an unconfirmed 404 stays a hard error rather than silently dropping data.