### PR TITLE
server: make landing page cache-stats URL configurable

### DIFF
--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -137,6 +137,10 @@ let
     "--cache-url"
     cfg.cacheUrl
   ]
+  ++ lib.optionals (cfg.serverUrl != null) [
+    "--server-url"
+    cfg.serverUrl
+  ]
   ++ lib.concatMap (f: [
     "--sign-key-path"
     (toString f)
@@ -328,6 +332,19 @@ in
         This is used to generate a landing page (index.html) with usage instructions
         and public keys, which is uploaded to the S3 bucket.
         Also used for redirecting requests to the niks3 server root to the public cache.
+      '';
+    };
+
+    serverUrl = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "https://niks3.example.com";
+      description = ''
+        Public URL of the niks3 server itself (distinct from cacheUrl when reads
+        are served straight from S3/CDN). The generated landing page fetches
+        cache stats from {serverUrl}/api/cache-stats. If unset, the page uses a
+        same-origin relative path, which only works when the cache is served by
+        niks3 or a proxy that routes /api/cache-stats to it.
       '';
     };
 

--- a/server/cache_stats.go
+++ b/server/cache_stats.go
@@ -10,7 +10,8 @@ import (
 )
 
 // CacheStatsHandler serves public cache inventory stats for the landing page.
-// CORS-open so the page can fetch it when served cross-origin from S3 or a CDN.
+// CORS "*" is safe only because the data is public and the endpoint is
+// unauthenticated: keep it that way, and never add Allow-Credentials.
 func (s *Service) CacheStatsHandler(w http.ResponseWriter, r *http.Request) {
 	stats, err := pg.New(s.Pool).GetObjectStats(r.Context())
 	if err != nil {

--- a/server/landing_page.go
+++ b/server/landing_page.go
@@ -19,10 +19,18 @@ type landingPageData struct {
 	PublicKeys       []string
 	PublicKeysJoined string
 	CacheURL         string
+	// CacheStatsURL is where the page fetches inventory stats from: absolute
+	// when ServerURL is set, else a same-origin relative path.
+	CacheStatsURL string
 }
 
 // GenerateLandingPage creates an HTML landing page with the cache's public keys and usage instructions.
 func (s *Service) GenerateLandingPage(cacheURL string) (string, error) {
+	cacheStatsURL := "api/cache-stats"
+	if s.ServerURL != "" {
+		cacheStatsURL = strings.TrimRight(s.ServerURL, "/") + "/api/cache-stats"
+	}
+
 	publicKeys := make([]string, 0, len(s.SigningKeys))
 	for _, key := range s.SigningKeys {
 		pubKey, err := key.PublicKey()
@@ -38,6 +46,7 @@ func (s *Service) GenerateLandingPage(cacheURL string) (string, error) {
 		PublicKeys:       publicKeys,
 		PublicKeysJoined: strings.Join(publicKeys, " "),
 		CacheURL:         cacheURL,
+		CacheStatsURL:    cacheStatsURL,
 	}
 
 	tmpl, err := template.New("landing").Parse(landingPageTemplate)

--- a/server/landing_page.html
+++ b/server/landing_page.html
@@ -307,7 +307,7 @@ extra-trusted-public-keys = {{ .PublicKeysJoined }}</code></pre>
             // Abort a slow or unreachable niks3; the section stays hidden on failure.
             var ctrl = new AbortController();
             var timer = setTimeout(function () { ctrl.abort(); }, 3000);
-            fetch("api/cache-stats", { signal: ctrl.signal })
+            fetch("{{ .CacheStatsURL }}", { signal: ctrl.signal })
                 .then(function (r) { if (!r.ok) throw new Error(r.status); return r.json(); })
                 .then(function (s) {
                     document.getElementById("stat-objects").textContent = s.objects.toLocaleString();

--- a/server/landing_page_test.go
+++ b/server/landing_page_test.go
@@ -53,4 +53,23 @@ func TestGenerateLandingPage(t *testing.T) {
 	if !strings.Contains(html, "</html>") {
 		t.Error("Landing page does not end with closing html tag")
 	}
+
+	// Without ServerURL the page fetches stats from a same-origin relative path.
+	// html/template escapes "/" as "\/" in the JS context, so undo it first.
+	if !strings.Contains(strings.ReplaceAll(html, `\/`, "/"), `fetch("api/cache-stats"`) {
+		t.Error("expected same-origin relative cache-stats fetch when ServerURL is unset")
+	}
+
+	// With ServerURL set the page fetches stats from the absolute niks3 URL.
+	withServer, err := (&server.Service{
+		SigningKeys: []*signing.Key{key},
+		ServerURL:   "https://niks3.example.com/",
+	}).GenerateLandingPage("https://cache.example.com")
+	if err != nil {
+		t.Fatalf("Failed to generate landing page: %v", err)
+	}
+
+	if !strings.Contains(strings.ReplaceAll(withServer, `\/`, "/"), `fetch("https://niks3.example.com/api/cache-stats"`) {
+		t.Error("expected absolute cache-stats fetch when ServerURL is set")
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -117,6 +117,9 @@ func parseArgs() (*options, error) {
 	flag.StringVar(&apiTokenPath, "api-token-path", getEnvOrDefault("NIKS3_API_TOKEN_PATH", ""), "API token file path")
 	flag.StringVar(&opts.CacheURL, "cache-url", getEnvOrDefault("NIKS3_CACHE_URL", ""),
 		"Public cache URL for the landing page (e.g., https://cache.example.com)")
+	flag.StringVar(&opts.ServerURL, "server-url", getEnvOrDefault("NIKS3_SERVER_URL", ""),
+		"Public niks3 server URL the landing page fetches cache stats from (e.g., https://niks3.example.com); "+
+			"defaults to a same-origin relative path")
 	flag.StringVar(&opts.OIDCConfigPath, "oidc-config", getEnvOrDefault("NIKS3_OIDC_CONFIG", ""),
 		"Path to OIDC configuration file (JSON format)")
 	flag.IntVar(&opts.S3Concurrency, "s3-concurrency", getEnvOrDefaultInt("NIKS3_S3_CONCURRENCY", defaultS3Concurrency),

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,7 @@ type options struct {
 
 	SignKeyPaths    []string
 	CacheURL        string
+	ServerURL       string
 	OIDCConfigPath  string
 	EnableReadProxy bool
 
@@ -91,6 +92,7 @@ type Service struct {
 	APIToken              string
 	SigningKeys           []*signing.Key
 	CacheURL              string
+	ServerURL             string
 	OIDCValidator         *oidc.Validator
 	EnableReadProxy       bool
 	MTLSProxyHeader       string
@@ -222,6 +224,7 @@ func runServer(opts *options) error {
 		MTLSBoundSubjects:     opts.MTLSBoundSubjects,
 		MTLSBoundSubjectsRead: opts.MTLSBoundSubjectsRead,
 		CacheURL:              opts.CacheURL,
+		ServerURL:             opts.ServerURL,
 		GCTasks:               NewGCTaskStore(),
 		Metrics:               NewMetrics(),
 	}


### PR DESCRIPTION

The landing page is served from the cache origin (often S3/CDN), which
is a different host than the niks3 server. The relative "api/cache-stats"
fetch therefore hit the object store and 404'd, so stats never loaded.

Add --server-url for the public niks3 URL; the page fetches stats from
${server-url}/api/cache-stats when set, falling back to the same-origin
relative path otherwise. The cache-stats handler is already CORS-open,
so the cross-origin fetch works.
