### PR TITLE
server: fix service teardown race in OIDC auth test

### DIFF
--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -295,7 +295,7 @@ func TestService_AuthMiddleware_OIDC(t *testing.T) {
 
 	// Create test service with OIDC validator
 	service := createTestService(t)
-	defer service.Close()
+	t.Cleanup(service.Close)
 
 	service.Pool.Close() // health check works without DB
 	service.OIDCValidator = validator


### PR DESCRIPTION

TestService_AuthMiddleware_OIDC runs subtests with t.Parallel(). Parallel
subtests stay paused until the parent function returns, so the deferred
service.Close() ran before they resumed and used the service. Use t.Cleanup,
which runs only after all subtests finish.


