### PR TITLE
dependabot: group updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      gomod:
+        patterns:
+          - "*"
   - package-ecosystem: "nix"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      nix:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduce PR noise by combining all gomod and nix dependency bumps
into a single PR per ecosystem instead of one PR per dependency.
