### PR TITLE
benchmark: parameterize upload benchmark and add disk image closure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ To run the benchmark:
 
 ```bash
 cd server
-go test -bench=BenchmarkPythonClosure -benchtime=3x -v
+go test -bench=BenchmarkUploadClosure -benchtime=3x -v
 ```
 
 ## Contributing S3 Provider Testing Results

--- a/nix/benchmark/benchmark-disk-image.nix
+++ b/nix/benchmark/benchmark-disk-image.nix
@@ -1,0 +1,14 @@
+{ pkgs }:
+# Ext4 image with a small closure: a single large NAR that exercises
+# streaming compression and multipart upload.
+pkgs.callPackage "${pkgs.path}/nixos/lib/make-ext4-fs.nix" {
+  storePaths = [
+    (pkgs.python3.withPackages (
+      ps: with ps; [
+        numpy
+        pandas
+      ]
+    ))
+  ];
+  volumeLabel = "niks3-bench";
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -11,6 +11,7 @@ let
     niks3-tests = pkgs.callPackage ./niks3-tests.nix { inherit (pkgs) go; };
     mock-oidc-server = pkgs.callPackage ./mock-oidc-server.nix { };
     benchmark-closure = pkgs.callPackage ../benchmark/benchmark-closure.nix { };
+    benchmark-disk-image = pkgs.callPackage ../benchmark/benchmark-disk-image.nix { };
     default = niks3;
   };
 in

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -10,16 +10,19 @@ import (
 	"testing"
 )
 
-// BenchmarkPythonClosure benchmarks building a Python closure with
-// common dependencies and uploading it to S3.
-//
-// This benchmark measures the end-to-end performance of:
-// 1. Building a Python environment with popular packages (if not already built)
-// 2. Uploading the entire closure to S3 via the niks3 server
-//
-// The Python closure is defined in nix/benchmark/python-closure.nix
-// and can be built with: nix build .#python-closure.
-func BenchmarkPythonClosure(b *testing.B) {
+// benchmarkClosures lists the flake attributes (see nix/benchmark) used as
+// upload workloads: many small/medium NARs vs. one large NAR.
+var benchmarkClosures = []struct { //nolint:gochecknoglobals // benchmark table
+	name string
+	attr string
+}{
+	{name: "PythonClosure", attr: ".#benchmark-closure"},
+	{name: "DiskImage", attr: ".#benchmark-disk-image"},
+}
+
+// BenchmarkUploadClosure measures uploading pre-built closures to S3 via the
+// niks3 server. Building the closure with nix is not timed.
+func BenchmarkUploadClosure(b *testing.B) {
 	ctx := context.Background()
 
 	// Find the git repository root
@@ -30,20 +33,29 @@ func BenchmarkPythonClosure(b *testing.B) {
 
 	projectRoot := strings.TrimSpace(string(gitRoot))
 
-	// Build the Python closure once before benchmarking
-	b.Log("Building Python closure (this may take a while on first run)...")
+	for _, bc := range benchmarkClosures {
+		b.Run(bc.name, func(b *testing.B) {
+			benchmarkUploadClosure(ctx, b, projectRoot, bc.attr)
+		})
+	}
+}
 
-	cmd := exec.CommandContext(ctx, "nix", "--extra-experimental-features", "nix-command flakes", "build", ".#benchmark-closure", "--print-out-paths", "--no-link")
+func benchmarkUploadClosure(ctx context.Context, b *testing.B, projectRoot, flakeAttr string) {
+	b.Helper()
+
+	b.Logf("Building %s (this may take a while on first run)...", flakeAttr)
+
+	cmd := exec.CommandContext(ctx, "nix", "--extra-experimental-features", "nix-command flakes", "build", flakeAttr, "--print-out-paths", "--no-link")
 	cmd.Dir = projectRoot
 
 	output, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			b.Fatalf("Failed to build Python closure: %v\nStderr: %s", err, exitErr.Stderr)
+			b.Fatalf("Failed to build %s: %v\nStderr: %s", flakeAttr, err, exitErr.Stderr)
 		}
 
-		b.Fatalf("Failed to build Python closure: %v", err)
+		b.Fatalf("Failed to build %s: %v", flakeAttr, err)
 	}
 
 	closurePath := strings.TrimSpace(string(output))
@@ -56,8 +68,6 @@ func BenchmarkPythonClosure(b *testing.B) {
 	} else {
 		b.Logf("Closure size: %s", strings.TrimSpace(string(sizeOutput)))
 	}
-
-	// Reset the timer to exclude setup time
 
 	// Run the benchmark
 	for b.Loop() {


### PR DESCRIPTION
BenchmarkPythonClosure only covered many small/medium NARs. Rename it to BenchmarkUploadClosure with table-driven sub-benchmarks and add a benchmark-disk-image package (ext4 image via make-ext4-fs, ~1.3 GiB single NAR) to also exercise multipart upload and streaming zstd compression.

Local results (rustfs/minio + postgres, 16 cores):
- PythonClosure: ~1.5-1.6 s/op
- DiskImage: ~4 s/op, CPU dominated by zstd encode (~85% of samples)