### PR TITLE
server: record NARs in objects on multipart completion

### DIFF
--- a/client/metadata_tasks.go
+++ b/client/metadata_tasks.go
@@ -66,6 +66,7 @@ func (c *Client) uploadLog(ctx context.Context, task uploadTask, logPathsByKey m
 		return fmt.Errorf("uploading build log %s: %w", task.key, err)
 	}
 
+	c.RegisterUploadedObject(ctx, task.key)
 	slog.Debug("Uploaded build log", "key", task.key)
 
 	return nil
@@ -104,6 +105,7 @@ func (c *Client) uploadRealisation(ctx context.Context, task uploadTask, realisa
 		return fmt.Errorf("uploading realisation %s: %w", task.key, err)
 	}
 
+	c.RegisterUploadedObject(ctx, task.key)
 	slog.Debug("Uploaded realisation", "key", task.key)
 
 	return nil

--- a/client/nar_task.go
+++ b/client/nar_task.go
@@ -36,6 +36,7 @@ func (c *Client) uploadNARWithListing(
 			return fmt.Errorf("uploading listing %s: %w", lsTask.key, err)
 		}
 
+		c.RegisterUploadedObject(ctx, lsTask.key)
 		slog.Debug("Uploaded listing", "key", lsTask.key)
 	}
 

--- a/client/nar_upload.go
+++ b/client/nar_upload.go
@@ -71,9 +71,13 @@ func (c *Client) CompressAndUploadNAR(ctx context.Context, storePath string, nar
 	)
 
 	if obj.MultipartInfo != nil {
+		// The server records the object when the multipart upload completes.
 		listing, err = c.compressAndMultipartUploadNAR(ctx, storePath, narSize, obj.MultipartInfo, objectKey)
 	} else {
 		listing, err = c.compressAndSimpleUploadNAR(ctx, storePath, obj.PresignedURL, objectKey)
+		if err == nil {
+			c.RegisterUploadedObject(ctx, objectKey)
+		}
 	}
 
 	if err != nil {

--- a/client/parallel.go
+++ b/client/parallel.go
@@ -201,6 +201,7 @@ func (c *Client) uploadMetadataOnly(
 			return fmt.Errorf("uploading listing %s: %w", lsTask.key, err)
 		}
 
+		c.RegisterUploadedObject(ctx, lsTask.key)
 		slog.Debug("Uploaded listing", "key", lsTask.key)
 	}
 

--- a/client/register_upload.go
+++ b/client/register_upload.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+type completeUploadRequest struct {
+	ObjectKey string `json:"object_key"`
+}
+
+// RegisterUploadedObject notifies the server that objectKey was uploaded via a
+// presigned PUT, so the object is recorded even if the closure never commits.
+// Best effort: failures are logged, closure commit still records the object.
+func (c *Client) RegisterUploadedObject(ctx context.Context, objectKey string) {
+	reqURL := c.baseURL.JoinPath("api/uploads/complete")
+
+	err := c.doJSONRequest(ctx, http.MethodPost, reqURL.String(),
+		completeUploadRequest{ObjectKey: objectKey}, nil, http.StatusOK, http.StatusNoContent)
+	if err != nil {
+		slog.Warn("Failed to register uploaded object", "key", objectKey, "error", err)
+	}
+}

--- a/client/upload.go
+++ b/client/upload.go
@@ -419,6 +419,7 @@ func (c *Client) uploadNarinfosInParallel(ctx context.Context, narinfos []narinf
 				return fmt.Errorf("uploading narinfo %s: unexpected status %d", task.key, resp.StatusCode)
 			}
 
+			c.RegisterUploadedObject(ctx, task.key)
 			slog.Debug("Uploaded narinfo", "key", task.key, "size", len(compressed))
 
 			return nil

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -18,7 +18,10 @@ packages
     nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.golangci-lint ];
     buildPhase = ''
       HOME=$TMPDIR
-      golangci-lint run
+      # Cap parallelism at the allotted build cores; golangci-lint defaults to
+      # all CPUs, which exhausts process limits on shared builders.
+      export GOMAXPROCS=$NIX_BUILD_CORES
+      golangci-lint run --concurrency "$NIX_BUILD_CORES"
     '';
     installPhase = ''
       touch $out
@@ -38,6 +41,9 @@ packages
       }
       ''
         export HOME=$TMPDIR
+        # Cap runtime parallelism at the allotted build cores to avoid hitting
+        # process limits on shared builders.
+        export GOMAXPROCS=$NIX_BUILD_CORES
 
         echo "Running client tests..."
         niks3-client.test -test.v

--- a/server/pg/query.sql
+++ b/server/pg/query.sql
@@ -34,13 +34,9 @@ WHERE key = any($1::varchar []);
 SELECT commit_pending_closure($1::bigint);
 
 -- name: RegisterCompletedObject :exec
--- Record an object as present as soon as its (multipart) upload completes,
--- instead of waiting for the whole closure to commit. Without this, a NAR that
--- uploaded successfully but whose closure never committed -- e.g. because a
--- sibling object in the same push batch failed, or the push process was killed
--- -- stays unknown to the objects table and is re-offered for upload by every
--- later closure that references it, leaking an orphaned multipart upload each
--- time. ON CONFLICT resurrects a tombstoned row, matching commit_pending_closure.
+-- Record an object as soon as its upload completes so later closures don't
+-- re-offer it if this closure never commits. ON CONFLICT resurrects a
+-- tombstoned row, matching commit_pending_closure.
 INSERT INTO objects (key, refs)
 VALUES (sqlc.arg(key), sqlc.arg(refs)::varchar [])
 ON CONFLICT (key) DO UPDATE SET

--- a/server/pg/query.sql
+++ b/server/pg/query.sql
@@ -35,13 +35,30 @@ SELECT commit_pending_closure($1::bigint);
 
 -- name: RegisterCompletedObject :exec
 -- Record an object as soon as its upload completes so later closures don't
--- re-offer it if this closure never commits. ON CONFLICT resurrects a
--- tombstoned row, matching commit_pending_closure.
-INSERT INTO objects (key, refs)
-VALUES (sqlc.arg(key), sqlc.arg(refs)::varchar [])
+-- re-offer it if this closure never commits. Conflict handling matches
+-- commit_pending_closure: merge refs, keep a known size, resurrect tombstones.
+INSERT INTO objects (key, refs, size)
+VALUES (sqlc.arg(key), sqlc.arg(refs)::varchar [], sqlc.arg(size))
 ON CONFLICT (key) DO UPDATE SET
+    refs = (
+        SELECT ARRAY(
+            SELECT DISTINCT unnest(objects.refs || excluded.refs)
+        )
+    ),
+    size = coalesce(objects.size, excluded.size),
     deleted_at = NULL,
     first_deleted_at = NULL;
+
+-- name: GetPendingObject :one
+SELECT refs, size FROM pending_objects
+WHERE pending_closure_id = $1 AND key = $2;
+
+-- name: GetPendingObjectByKey :one
+-- Any pending closure's row for this key; used to recover refs/size when the
+-- upload is registered outside closure commit.
+SELECT refs, size FROM pending_objects
+WHERE key = $1
+LIMIT 1;
 
 -- name: CleanupPendingClosures :execrows
 WITH cutoff_time AS (

--- a/server/pg/query.sql
+++ b/server/pg/query.sql
@@ -33,6 +33,20 @@ WHERE key = any($1::varchar []);
 -- name: CommitPendingClosure :exec
 SELECT commit_pending_closure($1::bigint);
 
+-- name: RegisterCompletedObject :exec
+-- Record an object as present as soon as its (multipart) upload completes,
+-- instead of waiting for the whole closure to commit. Without this, a NAR that
+-- uploaded successfully but whose closure never committed -- e.g. because a
+-- sibling object in the same push batch failed, or the push process was killed
+-- -- stays unknown to the objects table and is re-offered for upload by every
+-- later closure that references it, leaking an orphaned multipart upload each
+-- time. ON CONFLICT resurrects a tombstoned row, matching commit_pending_closure.
+INSERT INTO objects (key, refs)
+VALUES (sqlc.arg(key), sqlc.arg(refs)::varchar [])
+ON CONFLICT (key) DO UPDATE SET
+    deleted_at = NULL,
+    first_deleted_at = NULL;
+
 -- name: CleanupPendingClosures :execrows
 WITH cutoff_time AS (
     SELECT timezone('UTC', now()) - interval '1 second' * $1::int AS time

--- a/server/pg/query.sql.go
+++ b/server/pg/query.sql.go
@@ -329,6 +329,48 @@ func (q *Queries) GetOldMultipartUploads(ctx context.Context, dollar_1 int32) ([
 	return items, nil
 }
 
+const getPendingObject = `-- name: GetPendingObject :one
+SELECT refs, size FROM pending_objects
+WHERE pending_closure_id = $1 AND key = $2
+`
+
+type GetPendingObjectParams struct {
+	PendingClosureID int64  `json:"pending_closure_id"`
+	Key              string `json:"key"`
+}
+
+type GetPendingObjectRow struct {
+	Refs []string    `json:"refs"`
+	Size pgtype.Int8 `json:"size"`
+}
+
+func (q *Queries) GetPendingObject(ctx context.Context, arg GetPendingObjectParams) (GetPendingObjectRow, error) {
+	row := q.db.QueryRow(ctx, getPendingObject, arg.PendingClosureID, arg.Key)
+	var i GetPendingObjectRow
+	err := row.Scan(&i.Refs, &i.Size)
+	return i, err
+}
+
+const getPendingObjectByKey = `-- name: GetPendingObjectByKey :one
+SELECT refs, size FROM pending_objects
+WHERE key = $1
+LIMIT 1
+`
+
+type GetPendingObjectByKeyRow struct {
+	Refs []string    `json:"refs"`
+	Size pgtype.Int8 `json:"size"`
+}
+
+// Any pending closure's row for this key; used to recover refs/size when the
+// upload is registered outside closure commit.
+func (q *Queries) GetPendingObjectByKey(ctx context.Context, key string) (GetPendingObjectByKeyRow, error) {
+	row := q.db.QueryRow(ctx, getPendingObjectByKey, key)
+	var i GetPendingObjectByKeyRow
+	err := row.Scan(&i.Refs, &i.Size)
+	return i, err
+}
+
 const getPendingObjectKeys = `-- name: GetPendingObjectKeys :many
 SELECT key FROM pending_objects
 WHERE pending_closure_id = $1
@@ -537,23 +579,30 @@ func (q *Queries) MarkStaleObjects(ctx context.Context) (int64, error) {
 }
 
 const registerCompletedObject = `-- name: RegisterCompletedObject :exec
-INSERT INTO objects (key, refs)
-VALUES ($1, $2::varchar [])
+INSERT INTO objects (key, refs, size)
+VALUES ($1, $2::varchar [], $3)
 ON CONFLICT (key) DO UPDATE SET
+    refs = (
+        SELECT ARRAY(
+            SELECT DISTINCT unnest(objects.refs || excluded.refs)
+        )
+    ),
+    size = coalesce(objects.size, excluded.size),
     deleted_at = NULL,
     first_deleted_at = NULL
 `
 
 type RegisterCompletedObjectParams struct {
-	Key  string   `json:"key"`
-	Refs []string `json:"refs"`
+	Key  string      `json:"key"`
+	Refs []string    `json:"refs"`
+	Size pgtype.Int8 `json:"size"`
 }
 
 // Record an object as soon as its upload completes so later closures don't
-// re-offer it if this closure never commits. ON CONFLICT resurrects a
-// tombstoned row, matching commit_pending_closure.
+// re-offer it if this closure never commits. Conflict handling matches
+// commit_pending_closure: merge refs, keep a known size, resurrect tombstones.
 func (q *Queries) RegisterCompletedObject(ctx context.Context, arg RegisterCompletedObjectParams) error {
-	_, err := q.db.Exec(ctx, registerCompletedObject, arg.Key, arg.Refs)
+	_, err := q.db.Exec(ctx, registerCompletedObject, arg.Key, arg.Refs, arg.Size)
 	return err
 }
 

--- a/server/pg/query.sql.go
+++ b/server/pg/query.sql.go
@@ -549,13 +549,9 @@ type RegisterCompletedObjectParams struct {
 	Refs []string `json:"refs"`
 }
 
-// Record an object as present as soon as its (multipart) upload completes,
-// instead of waiting for the whole closure to commit. Without this, a NAR that
-// uploaded successfully but whose closure never committed -- e.g. because a
-// sibling object in the same push batch failed, or the push process was killed
-// -- stays unknown to the objects table and is re-offered for upload by every
-// later closure that references it, leaking an orphaned multipart upload each
-// time. ON CONFLICT resurrects a tombstoned row, matching commit_pending_closure.
+// Record an object as soon as its upload completes so later closures don't
+// re-offer it if this closure never commits. ON CONFLICT resurrects a
+// tombstoned row, matching commit_pending_closure.
 func (q *Queries) RegisterCompletedObject(ctx context.Context, arg RegisterCompletedObjectParams) error {
 	_, err := q.db.Exec(ctx, registerCompletedObject, arg.Key, arg.Refs)
 	return err

--- a/server/pg/query.sql.go
+++ b/server/pg/query.sql.go
@@ -536,6 +536,31 @@ func (q *Queries) MarkStaleObjects(ctx context.Context) (int64, error) {
 	return result.RowsAffected(), nil
 }
 
+const registerCompletedObject = `-- name: RegisterCompletedObject :exec
+INSERT INTO objects (key, refs)
+VALUES ($1, $2::varchar [])
+ON CONFLICT (key) DO UPDATE SET
+    deleted_at = NULL,
+    first_deleted_at = NULL
+`
+
+type RegisterCompletedObjectParams struct {
+	Key  string   `json:"key"`
+	Refs []string `json:"refs"`
+}
+
+// Record an object as present as soon as its (multipart) upload completes,
+// instead of waiting for the whole closure to commit. Without this, a NAR that
+// uploaded successfully but whose closure never committed -- e.g. because a
+// sibling object in the same push batch failed, or the push process was killed
+// -- stays unknown to the objects table and is re-offered for upload by every
+// later closure that references it, leaking an orphaned multipart upload each
+// time. ON CONFLICT resurrects a tombstoned row, matching commit_pending_closure.
+func (q *Queries) RegisterCompletedObject(ctx context.Context, arg RegisterCompletedObjectParams) error {
+	_, err := q.db.Exec(ctx, registerCompletedObject, arg.Key, arg.Refs)
+	return err
+}
+
 const upsertPin = `-- name: UpsertPin :exec
 INSERT INTO pins (name, narinfo_key, store_path, created_at, updated_at)
 VALUES ($1, $2, $3, timezone('UTC', now()), timezone('UTC', now()))

--- a/server/reupload_uncommitted_test.go
+++ b/server/reupload_uncommitted_test.go
@@ -1,0 +1,82 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+)
+
+// TestCompletedNarNotReofferedAcrossClosures is a regression test for a NAR that
+// has been fully uploaded to S3 (its multipart upload completed) but whose
+// closure was never committed -- exactly what happens in CI when one object in
+// a batch fails (or the push process is killed) after a sibling NAR already
+// finished uploading.
+//
+// CompleteMultipartUploadHandler finalizes the object in S3 and drops its
+// multipart_uploads tracking row, but the object is only recorded in the
+// `objects` table at closure commit (commit_pending_closure). So a completed-
+// but-uncommitted NAR stays present in S3 yet is treated as missing forever:
+// every later closure re-opens a fresh multipart upload for it. When the client
+// then notices the object already exists and skips, that fresh multipart is
+// abandoned with zero parts and leaks. Over many CI runs this produces
+// thousands of orphaned zero-part multipart uploads and needless re-uploads,
+// and it prevents the affected path from being served from the cache.
+func TestCompletedNarNotReofferedAcrossClosures(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	// Unique nix-base32 hashes (alphabet excludes e/o/t/u) to avoid collisions
+	// with other -parallel tests sharing the bucket.
+	narKey := narKeyFor("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh01")
+	firstNarinfo := "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh10.narinfo"
+	secondNarinfo := "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh20.narinfo"
+
+	closureFor := func(narinfoKey string) map[string]any {
+		return map[string]any{
+			"closure": narinfoKey,
+			"objects": []map[string]any{
+				{"key": narinfoKey, "type": "narinfo", "refs": []string{narKey}},
+				{"key": narKey, "type": "nar", "refs": []string{}, "nar_size": 100 * 1024 * 1024},
+			},
+		}
+	}
+
+	// First closure: the server opens a multipart upload for the NAR.
+	first := createPendingClosure(t, service, closureFor(firstNarinfo))
+
+	nar := first.PendingObjects[narKey]
+	if nar.MultipartInfo == nil {
+		t.Fatalf("expected a multipart upload for the NAR on the first closure")
+	}
+
+	// Upload and complete the NAR: the object now exists in S3.
+	handleMultipartUpload(ctx, t, narKey, nar, service)
+
+	// Confirm the NAR is really in S3.
+	if _, err := service.MinioClient.StatObject(ctx, service.Bucket, narKey, minio.StatObjectOptions{}); err != nil {
+		t.Fatalf("NAR should be present in S3 after completing its multipart upload: %v", err)
+	}
+
+	// Deliberately do NOT commit the first closure: this models a batch where a
+	// sibling object failed (or the push was killed) after this NAR uploaded, so
+	// PushPaths returned before reaching CompletePendingClosure.
+
+	// A later build pushes a different closure that references the same NAR
+	// content. The NAR is already in S3, so the server must not ask the client
+	// to upload it again.
+	second := createPendingClosure(t, service, closureFor(secondNarinfo))
+
+	if reoffered, ok := second.PendingObjects[narKey]; ok {
+		t.Errorf("server re-offered an upload for a NAR already present in S3 "+
+			"(multipart=%v, presigned=%q); every such re-offer that the client "+
+			"then skips leaks an orphaned zero-part multipart upload",
+			reoffered.MultipartInfo != nil, reoffered.PresignedURL)
+	}
+}

--- a/server/reupload_uncommitted_test.go
+++ b/server/reupload_uncommitted_test.go
@@ -2,6 +2,8 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -60,5 +62,83 @@ func TestCompletedNarNotReofferedAcrossClosures(t *testing.T) {
 	if reoffered, ok := second.PendingObjects[narKey]; ok {
 		t.Errorf("NAR already in S3 was re-offered for upload (multipart=%v, presigned=%q)",
 			reoffered.MultipartInfo != nil, reoffered.PresignedURL)
+	}
+
+	// The registration must carry the client-reported size for object_stats.
+	var size *int64
+	if err := service.Pool.QueryRow(ctx, "SELECT size FROM objects WHERE key = $1", narKey).Scan(&size); err != nil {
+		t.Fatalf("failed to query registered object: %v", err)
+	}
+
+	if size == nil || *size != 100*1024*1024 {
+		t.Errorf("registered object size = %v, want %d", size, 100*1024*1024)
+	}
+}
+
+// A presigned (non-multipart) upload followed by POST /api/uploads/complete
+// must also be recorded, so an uncommitted closure does not cause re-uploads.
+func TestPresignedUploadRegisteredBeforeCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	narKey := narKeyFor("jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj01")
+	firstNarinfo := "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj10.narinfo"
+	secondNarinfo := "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj20.narinfo"
+
+	closureFor := func(narinfoKey string) map[string]any {
+		return map[string]any{
+			"closure": narinfoKey,
+			"objects": []map[string]any{
+				{"key": narinfoKey, "type": "narinfo", "refs": []string{narKey}},
+				{"key": narKey, "type": "nar", "refs": []string{}, "nar_size": 1024},
+			},
+		}
+	}
+
+	first := createPendingClosure(t, service, closureFor(firstNarinfo))
+
+	nar := first.PendingObjects[narKey]
+	if nar.PresignedURL == "" {
+		t.Fatalf("expected a presigned URL for a small NAR")
+	}
+
+	handlePresignedUpload(ctx, t, nar.PresignedURL)
+
+	// Registering an unknown key must be rejected.
+	body, err := json.Marshal(map[string]any{"object_key": narKeyFor("jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj99")})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checkNotFound := checkStatusCode(http.StatusNotFound)
+	testRequest(t, &TestRequest{
+		method:        "POST",
+		path:          "/api/uploads/complete",
+		body:          body,
+		handler:       service.CompleteUploadHandler,
+		checkResponse: &checkNotFound,
+	})
+
+	body, err = json.Marshal(map[string]any{"object_key": narKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testRequest(t, &TestRequest{
+		method:  "POST",
+		path:    "/api/uploads/complete",
+		body:    body,
+		handler: service.CompleteUploadHandler,
+	})
+
+	// First closure never commits; a second closure must not re-offer the NAR.
+	second := createPendingClosure(t, service, closureFor(secondNarinfo))
+	if reoffered, ok := second.PendingObjects[narKey]; ok {
+		t.Errorf("NAR already in S3 was re-offered for upload (presigned=%q)", reoffered.PresignedURL)
 	}
 }

--- a/server/reupload_uncommitted_test.go
+++ b/server/reupload_uncommitted_test.go
@@ -8,21 +8,10 @@ import (
 	"github.com/minio/minio-go/v7"
 )
 
-// TestCompletedNarNotReofferedAcrossClosures is a regression test for a NAR that
-// has been fully uploaded to S3 (its multipart upload completed) but whose
-// closure was never committed -- exactly what happens in CI when one object in
-// a batch fails (or the push process is killed) after a sibling NAR already
-// finished uploading.
-//
-// CompleteMultipartUploadHandler finalizes the object in S3 and drops its
-// multipart_uploads tracking row, but the object is only recorded in the
-// `objects` table at closure commit (commit_pending_closure). So a completed-
-// but-uncommitted NAR stays present in S3 yet is treated as missing forever:
-// every later closure re-opens a fresh multipart upload for it. When the client
-// then notices the object already exists and skips, that fresh multipart is
-// abandoned with zero parts and leaks. Over many CI runs this produces
-// thousands of orphaned zero-part multipart uploads and needless re-uploads,
-// and it prevents the affected path from being served from the cache.
+// Regression test: a NAR whose multipart upload completed but whose closure
+// never committed (sibling object failed, push killed) must not be re-offered
+// for upload by later closures, since each re-offer leaks an orphaned
+// zero-part multipart upload.
 func TestCompletedNarNotReofferedAcrossClosures(t *testing.T) {
 	t.Parallel()
 
@@ -64,19 +53,12 @@ func TestCompletedNarNotReofferedAcrossClosures(t *testing.T) {
 		t.Fatalf("NAR should be present in S3 after completing its multipart upload: %v", err)
 	}
 
-	// Deliberately do NOT commit the first closure: this models a batch where a
-	// sibling object failed (or the push was killed) after this NAR uploaded, so
-	// PushPaths returned before reaching CompletePendingClosure.
-
-	// A later build pushes a different closure that references the same NAR
-	// content. The NAR is already in S3, so the server must not ask the client
-	// to upload it again.
+	// Deliberately do NOT commit the first closure. A second closure referencing
+	// the same NAR must not be asked to upload it again.
 	second := createPendingClosure(t, service, closureFor(secondNarinfo))
 
 	if reoffered, ok := second.PendingObjects[narKey]; ok {
-		t.Errorf("server re-offered an upload for a NAR already present in S3 "+
-			"(multipart=%v, presigned=%q); every such re-offer that the client "+
-			"then skips leaks an orphaned zero-part multipart upload",
+		t.Errorf("NAR already in S3 was re-offered for upload (multipart=%v, presigned=%q)",
 			reoffered.MultipartInfo != nil, reoffered.PresignedURL)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -291,6 +291,7 @@ func runServer(opts *options) error {
 	mux.HandleFunc("POST /api/pending_closures/{id}/sign", service.AuthMiddleware(service.SignNarinfosHandler))
 	mux.HandleFunc("POST /api/pending_closures/{id}/complete", service.AuthMiddleware(service.CommitPendingClosureHandler))
 	mux.HandleFunc("POST /api/multipart/complete", service.AuthMiddleware(service.CompleteMultipartUploadHandler))
+	mux.HandleFunc("POST /api/uploads/complete", service.AuthMiddleware(service.CompleteUploadHandler))
 	mux.HandleFunc("POST /api/multipart/request-parts", service.AuthMiddleware(service.RequestMorePartsHandler))
 	mux.HandleFunc("HEAD /api/objects/{key...}", service.AuthMiddleware(service.ObjectExistsHandler))
 	mux.HandleFunc("GET /api/closures/{key}", service.AuthMiddleware(service.GetClosureHandler))

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mic92/niks3/server/pg"
 	"github.com/Mic92/niks3/server/signing"
+	"github.com/jackc/pgx/v5"
 	"github.com/minio/minio-go/v7"
 )
 
@@ -288,7 +289,8 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 
 	// Verify the upload is registered before touching S3, so clients cannot
 	// finalize multipart uploads outside the pending-closure book-keeping.
-	if _, ok := s.getValidMultipartUpload(w, r, req.ObjectKey, req.UploadID); !ok {
+	upload, ok := s.getValidMultipartUpload(w, r, req.ObjectKey, req.UploadID)
+	if !ok {
 		return
 	}
 
@@ -345,11 +347,13 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 	// Record the object now rather than at closure commit: if the closure never
 	// commits (sibling upload failed, push killed), later closures would keep
 	// re-offering this NAR and leak an orphaned multipart upload each time.
-	if err := queries.RegisterCompletedObject(r.Context(), pg.RegisterCompletedObjectParams{
-		Key:  req.ObjectKey,
-		Refs: []string{},
-	}); err != nil {
+	// On error fail the request before dropping the tracking row, so a retry
+	// re-attempts the idempotent registration.
+	if err := s.registerCompletedObject(r.Context(), upload.PendingClosureID, req.ObjectKey); err != nil {
 		slog.Error("Failed to register completed object", "error", err, "object_key", req.ObjectKey)
+		http.Error(w, "failed to register completed object", http.StatusInternalServerError)
+
+		return
 	}
 
 	// Delete the multipart upload tracking row
@@ -364,6 +368,107 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 
 	slog.Info("Completed multipart upload", "object_key", req.ObjectKey, "upload_id", req.UploadID, "parts", len(req.Parts))
 
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// registerCompletedObject records an uploaded object in the objects table,
+// using refs/size from its pending_objects row in the given closure. A
+// missing row (closure already cleaned up) is not an error; the object is
+// registered with empty refs and unknown size.
+func (s *Service) registerCompletedObject(ctx context.Context, pendingClosureID int64, objectKey string) error {
+	queries := pg.New(s.Pool)
+
+	row, err := queries.GetPendingObject(ctx, pg.GetPendingObjectParams{
+		PendingClosureID: pendingClosureID,
+		Key:              objectKey,
+	})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get pending object %q: %w", objectKey, err)
+	}
+
+	if row.Refs == nil {
+		row.Refs = []string{}
+	}
+
+	if err := queries.RegisterCompletedObject(ctx, pg.RegisterCompletedObjectParams{
+		Key:  objectKey,
+		Refs: row.Refs,
+		Size: row.Size,
+	}); err != nil {
+		return fmt.Errorf("register completed object %q: %w", objectKey, err)
+	}
+
+	return nil
+}
+
+type completeUploadRequest struct {
+	ObjectKey string `json:"object_key"`
+}
+
+// CompleteUploadHandler handles POST /api/uploads/complete. Clients call it
+// after a successful presigned PUT so the object is recorded even if its
+// closure never commits. The key must belong to a pending object and the
+// object must exist in S3, so clients cannot register arbitrary keys.
+func (s *Service) CompleteUploadHandler(w http.ResponseWriter, r *http.Request) {
+	defer closeRequestBody(r)
+
+	req := &completeUploadRequest{}
+	if !decodeJSONBody(w, r, maxAPIRequestBody, req) {
+		return
+	}
+
+	if req.ObjectKey == "" {
+		http.Error(w, "missing object_key", http.StatusBadRequest)
+
+		return
+	}
+
+	queries := pg.New(s.Pool)
+
+	row, err := queries.GetPendingObjectByKey(r.Context(), req.ObjectKey)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "object is not pending upload", http.StatusNotFound)
+
+			return
+		}
+
+		slog.Error("Failed to look up pending object", "error", err, "object_key", req.ObjectKey)
+		http.Error(w, "failed to look up pending object", http.StatusInternalServerError)
+
+		return
+	}
+
+	if row.Refs == nil {
+		row.Refs = []string{}
+	}
+
+	exists, err := s.objectExistsInS3(r.Context(), req.ObjectKey)
+	if err != nil {
+		slog.Error("Failed to stat object", "error", err, "object_key", req.ObjectKey)
+		http.Error(w, "failed to stat object", http.StatusInternalServerError)
+
+		return
+	}
+
+	if !exists {
+		http.Error(w, "object not found in S3", http.StatusNotFound)
+
+		return
+	}
+
+	if err := queries.RegisterCompletedObject(r.Context(), pg.RegisterCompletedObjectParams{
+		Key:  req.ObjectKey,
+		Refs: row.Refs,
+		Size: row.Size,
+	}); err != nil {
+		slog.Error("Failed to register completed object", "error", err, "object_key", req.ObjectKey)
+		http.Error(w, "failed to register completed object", http.StatusInternalServerError)
+
+		return
+	}
+
+	slog.Info("Registered completed upload", "object_key", req.ObjectKey)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -342,6 +342,19 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		s.S3RateLimiter.RecordSuccess()
 	}
 
+	// Record the object as present as soon as it is finalized in S3, rather than
+	// waiting for the whole closure to commit. Otherwise a NAR whose closure
+	// never commits -- e.g. a sibling object in the same push batch failed, or
+	// the push process was killed -- stays unknown to the objects table and is
+	// re-offered for upload by every later closure that references it, leaking an
+	// orphaned multipart upload each time.
+	if err := queries.RegisterCompletedObject(r.Context(), pg.RegisterCompletedObjectParams{
+		Key:  req.ObjectKey,
+		Refs: []string{},
+	}); err != nil {
+		slog.Error("Failed to register completed object", "error", err, "object_key", req.ObjectKey)
+	}
+
 	// Delete the multipart upload tracking row
 	if err := queries.DeleteMultipartUpload(r.Context(), req.UploadID); err != nil {
 		// Log the error but don't fail the request - the upload already succeeded in S3

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -342,12 +342,9 @@ func (s *Service) CompleteMultipartUploadHandler(w http.ResponseWriter, r *http.
 		s.S3RateLimiter.RecordSuccess()
 	}
 
-	// Record the object as present as soon as it is finalized in S3, rather than
-	// waiting for the whole closure to commit. Otherwise a NAR whose closure
-	// never commits -- e.g. a sibling object in the same push batch failed, or
-	// the push process was killed -- stays unknown to the objects table and is
-	// re-offered for upload by every later closure that references it, leaking an
-	// orphaned multipart upload each time.
+	// Record the object now rather than at closure commit: if the closure never
+	// commits (sibling upload failed, push killed), later closures would keep
+	// re-offering this NAR and leak an orphaned multipart upload each time.
 	if err := queries.RegisterCompletedObject(r.Context(), pg.RegisterCompletedObjectParams{
 		Key:  req.ObjectKey,
 		Refs: []string{},


### PR DESCRIPTION
`CompleteMultipartUploadHandler` finalizes a NAR in S3 but only `commit_pending_closure` records it in the `objects` table. A NAR that uploaded but whose closure never committed — a sibling object in the push batch failed, or the push was killed — is therefore re-offered for upload by every later closure that references it, leaking an orphaned zero-part multipart upload each run.

Record the object in `objects` as soon as its multipart completes. Includes a regression test that fails without the change.

Fixes #446
