### PR TITLE
server,client: add server-side max NAR size limit

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -89,4 +89,8 @@ type CacheConfig struct {
 	// the issuer passed via ?issuer=. Empty if no issuer was requested or no
 	// matching provider is configured.
 	OIDCAudience string `json:"oidc_audience,omitempty"`
+
+	// MaxNarSize is the maximum uncompressed NAR size in bytes the server
+	// accepts. Clients skip closures containing larger paths. 0 means unlimited.
+	MaxNarSize uint64 `json:"max_nar_size,omitempty"`
 }

--- a/client/cache_config.go
+++ b/client/cache_config.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Mic92/niks3/api"
+)
+
+// GetCacheConfig fetches the public cache configuration from the server
+// (GET /api/cache-config), including the maximum accepted NAR size.
+func (c *Client) GetCacheConfig(ctx context.Context) (*api.CacheConfig, error) {
+	cfg := &api.CacheConfig{}
+
+	url := c.baseURL.JoinPath("/api/cache-config")
+	if err := c.doJSONRequest(ctx, http.MethodGet, url.String(), nil, cfg, http.StatusOK); err != nil {
+		return nil, fmt.Errorf("fetching cache config: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/client/cache_config.go
+++ b/client/cache_config.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/Mic92/niks3/api"
@@ -19,4 +20,26 @@ func (c *Client) GetCacheConfig(ctx context.Context) (*api.CacheConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+type skippedUploadsRequest struct {
+	Paths    uint64 `json:"paths"`
+	NarBytes uint64 `json:"nar_bytes"`
+}
+
+// ReportSkippedUploads tells the server how many store paths were skipped
+// due to the max NAR size limit, so it can expose the numbers as metrics.
+// Best effort: failures are logged and the push continues.
+func (c *Client) ReportSkippedUploads(ctx context.Context, paths, narBytes uint64) {
+	if paths == 0 {
+		return
+	}
+
+	url := c.baseURL.JoinPath("/api/uploads/skipped")
+
+	err := c.doJSONRequest(ctx, http.MethodPost, url.String(),
+		skippedUploadsRequest{Paths: paths, NarBytes: narBytes}, nil, http.StatusOK, http.StatusNoContent)
+	if err != nil {
+		slog.Warn("Failed to report skipped uploads", "error", err)
+	}
 }

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -18,6 +18,9 @@ var ShellSplit = shellSplit //nolint:gochecknoglobals // test-only re-export
 // PartSizeForNAR re-exports partSizeForNAR for the external test package.
 var PartSizeForNAR = partSizeForNAR //nolint:gochecknoglobals // test-only re-export
 
+// FilterOversizedClosures re-exports filterOversizedClosures for the external test package.
+var FilterOversizedClosures = filterOversizedClosures //nolint:gochecknoglobals // test-only re-export
+
 // MultipartPartSize re-exports the default part size for tests.
 const MultipartPartSize = multipartPartSize
 

--- a/client/max_nar_size_test.go
+++ b/client/max_nar_size_test.go
@@ -25,7 +25,11 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("no limit keeps everything", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 0)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 0)
+		if skipped.Paths != 0 || skipped.NarBytes != 0 {
+			t.Errorf("skipped = %+v, want none", skipped)
+		}
+
 		if len(kept) != 2 || len(infos) != 3 {
 			t.Errorf("kept = %v, infos = %d, want all", kept, len(infos))
 		}
@@ -34,7 +38,11 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("closure with oversized dependency is skipped", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 2000)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 2000)
+		if skipped.Paths != 2 || skipped.NarBytes != 5100 {
+			t.Errorf("skipped = %+v, want 2 paths / 5100 bytes", skipped)
+		}
+
 		if !slices.Equal(kept, []string{small}) {
 			t.Errorf("kept = %v, want only %s", kept, small)
 		}
@@ -47,7 +55,11 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("all closures skipped", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos := client.FilterOversizedClosures([]string{wrapper}, pathInfos, 50)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper}, pathInfos, 50)
+		if skipped.Paths != 3 || skipped.NarBytes != 6100 {
+			t.Errorf("skipped = %+v, want 3 paths / 6100 bytes", skipped)
+		}
+
 		if len(kept) != 0 || len(infos) != 0 {
 			t.Errorf("kept = %v, infos = %v, want none", kept, infos)
 		}

--- a/client/max_nar_size_test.go
+++ b/client/max_nar_size_test.go
@@ -1,0 +1,55 @@
+package client_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+func TestFilterOversizedClosures(t *testing.T) {
+	t.Parallel()
+
+	const store = "/nix/store/"
+
+	small := store + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-small"
+	image := store + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-vm-image"
+	wrapper := store + "cccccccccccccccccccccccccccccccc-wrapper"
+
+	pathInfos := map[string]*client.PathInfo{
+		small:   {Path: small, NarSize: 1000},
+		image:   {Path: image, NarSize: 5000},
+		wrapper: {Path: wrapper, NarSize: 100, References: []string{image, small}},
+	}
+
+	t.Run("no limit keeps everything", func(t *testing.T) {
+		t.Parallel()
+
+		kept, infos := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 0)
+		if len(kept) != 2 || len(infos) != 3 {
+			t.Errorf("kept = %v, infos = %d, want all", kept, len(infos))
+		}
+	})
+
+	t.Run("closure with oversized dependency is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		kept, infos := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 2000)
+		if !slices.Equal(kept, []string{small}) {
+			t.Errorf("kept = %v, want only %s", kept, small)
+		}
+
+		if len(infos) != 1 || infos[small] == nil {
+			t.Errorf("pruned infos = %v, want only %s", infos, small)
+		}
+	})
+
+	t.Run("all closures skipped", func(t *testing.T) {
+		t.Parallel()
+
+		kept, infos := client.FilterOversizedClosures([]string{wrapper}, pathInfos, 50)
+		if len(kept) != 0 || len(infos) != 0 {
+			t.Errorf("kept = %v, infos = %v, want none", kept, infos)
+		}
+	})
+}

--- a/client/upload.go
+++ b/client/upload.go
@@ -306,14 +306,21 @@ func computeClosureMembership(topLevelPaths []string, pathInfos map[string]*Path
 	return closureMembership
 }
 
+// skippedUploads counts store paths (and their uncompressed NAR bytes)
+// dropped by filterOversizedClosures.
+type skippedUploads struct {
+	Paths    uint64
+	NarBytes uint64
+}
+
 // filterOversizedClosures drops top-level paths whose closure contains a path
 // with NarSize larger than maxNarSize. A limit of 0 disables filtering. It returns the kept
-// top-level paths and pathInfos pruned to paths still reachable from them.
-// Skipping only warns, never errors, so pushes and the build hook keep
-// succeeding under a server-side size policy.
-func filterOversizedClosures(topLevelPaths []string, pathInfos map[string]*PathInfo, maxNarSize uint64) ([]string, map[string]*PathInfo) {
+// top-level paths, pathInfos pruned to paths still reachable from them, and
+// counts of what was skipped. Skipping only warns, never errors, so pushes
+// and the build hook keep succeeding under a server-side size policy.
+func filterOversizedClosures(topLevelPaths []string, pathInfos map[string]*PathInfo, maxNarSize uint64) ([]string, map[string]*PathInfo, skippedUploads) {
 	if maxNarSize == 0 {
-		return topLevelPaths, pathInfos
+		return topLevelPaths, pathInfos, skippedUploads{}
 	}
 
 	closureMembership := computeClosureMembership(topLevelPaths, pathInfos)
@@ -337,7 +344,7 @@ nextClosure:
 	}
 
 	if len(kept) == len(topLevelPaths) {
-		return topLevelPaths, pathInfos
+		return topLevelPaths, pathInfos, skippedUploads{}
 	}
 
 	// Prune pathInfos to paths still reachable from the kept top-level paths.
@@ -351,7 +358,16 @@ nextClosure:
 		}
 	}
 
-	return kept, prunedInfos
+	var skipped skippedUploads
+
+	for path, info := range pathInfos {
+		if _, ok := prunedInfos[path]; !ok {
+			skipped.Paths++
+			skipped.NarBytes += info.NarSize
+		}
+	}
+
+	return kept, prunedInfos, skipped
 }
 
 // CreatePendingClosures creates pending closures and returns all pending objects and closure ID to narinfo key mapping.
@@ -527,7 +543,11 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 		maxNarSize = cfg.MaxNarSize
 	}
 
-	resolvedPaths, pathInfos = filterOversizedClosures(resolvedPaths, pathInfos, maxNarSize)
+	var skipped skippedUploads
+
+	resolvedPaths, pathInfos, skipped = filterOversizedClosures(resolvedPaths, pathInfos, maxNarSize)
+	c.ReportSkippedUploads(ctx, skipped.Paths, skipped.NarBytes)
+
 	if len(resolvedPaths) == 0 {
 		slog.Warn("All closures skipped by server max NAR size, nothing to upload")
 

--- a/client/upload.go
+++ b/client/upload.go
@@ -233,33 +233,7 @@ func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[
 	}
 
 	// Second pass: compute closure membership for each top-level path
-	// Build a map of which paths are reachable from each top-level path
-	closureMembership := make(map[string]map[string]bool) // topLevelPath -> set of reachable paths
-
-	for _, topLevelPath := range topLevelPaths {
-		reachable := make(map[string]bool)
-
-		var visit func(string)
-
-		visit = func(path string) {
-			if reachable[path] {
-				return
-			}
-
-			reachable[path] = true
-
-			pathInfo, ok := pathInfos[path]
-			if !ok {
-				return
-			}
-
-			for _, ref := range pathInfo.References {
-				visit(ref)
-			}
-		}
-		visit(topLevelPath)
-		closureMembership[topLevelPath] = reachable
-	}
+	closureMembership := computeClosureMembership(topLevelPaths, pathInfos)
 
 	// Third pass: create one ClosureInfo per top-level path with only its reachable objects
 	closures := make([]ClosureInfo, 0, len(topLevelPaths))
@@ -297,6 +271,87 @@ func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[
 		LogPathsByKey:     logPathsByKey,
 		RealisationsByKey: realisations,
 	}, nil
+}
+
+// computeClosureMembership returns, for each top-level path, the set of store
+// paths reachable from it via references.
+func computeClosureMembership(topLevelPaths []string, pathInfos map[string]*PathInfo) map[string]map[string]bool {
+	closureMembership := make(map[string]map[string]bool) // topLevelPath -> set of reachable paths
+
+	for _, topLevelPath := range topLevelPaths {
+		reachable := make(map[string]bool)
+
+		var visit func(string)
+
+		visit = func(path string) {
+			if reachable[path] {
+				return
+			}
+
+			reachable[path] = true
+
+			pathInfo, ok := pathInfos[path]
+			if !ok {
+				return
+			}
+
+			for _, ref := range pathInfo.References {
+				visit(ref)
+			}
+		}
+		visit(topLevelPath)
+		closureMembership[topLevelPath] = reachable
+	}
+
+	return closureMembership
+}
+
+// filterOversizedClosures drops top-level paths whose closure contains a path
+// with NarSize larger than maxNarSize. A limit of 0 disables filtering. It returns the kept
+// top-level paths and pathInfos pruned to paths still reachable from them.
+// Skipping only warns, never errors, so pushes and the build hook keep
+// succeeding under a server-side size policy.
+func filterOversizedClosures(topLevelPaths []string, pathInfos map[string]*PathInfo, maxNarSize uint64) ([]string, map[string]*PathInfo) {
+	if maxNarSize == 0 {
+		return topLevelPaths, pathInfos
+	}
+
+	closureMembership := computeClosureMembership(topLevelPaths, pathInfos)
+	kept := make([]string, 0, len(topLevelPaths))
+
+nextClosure:
+	for _, topLevelPath := range topLevelPaths {
+		for path := range closureMembership[topLevelPath] {
+			if info, ok := pathInfos[path]; ok && info.NarSize > maxNarSize {
+				slog.Warn("Skipping closure: path exceeds server max NAR size",
+					"top_level_path", topLevelPath,
+					"oversized_path", path,
+					"nar_size", info.NarSize,
+					"max_nar_size", maxNarSize)
+
+				continue nextClosure
+			}
+		}
+
+		kept = append(kept, topLevelPath)
+	}
+
+	if len(kept) == len(topLevelPaths) {
+		return topLevelPaths, pathInfos
+	}
+
+	// Prune pathInfos to paths still reachable from the kept top-level paths.
+	prunedInfos := make(map[string]*PathInfo)
+
+	for _, topLevelPath := range kept {
+		for path := range closureMembership[topLevelPath] {
+			if info, ok := pathInfos[path]; ok {
+				prunedInfos[path] = info
+			}
+		}
+	}
+
+	return kept, prunedInfos
 }
 
 // CreatePendingClosures creates pending closures and returns all pending objects and closure ID to narinfo key mapping.
@@ -454,10 +509,29 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 
 	slog.Debug("Found paths in closure", "count", len(pathInfos))
 
-	// Collect all closure paths to return to the caller.
+	// Collect all closure paths to return to the caller. This includes paths
+	// from closures skipped by the size filter below, so callers (e.g. the
+	// hook queue) treat them as handled instead of retrying forever.
 	closurePaths := make([]string, 0, len(pathInfos))
 	for storePath := range pathInfos {
 		closurePaths = append(closurePaths, storePath)
+	}
+
+	// Skip closures containing paths larger than the server's max NAR size.
+	// Fetched per push so the long-running hook picks up config changes.
+	var maxNarSize uint64
+
+	if cfg, err := c.GetCacheConfig(ctx); err != nil {
+		slog.Warn("Failed to fetch cache config, uploading without size limit", "error", err)
+	} else {
+		maxNarSize = cfg.MaxNarSize
+	}
+
+	resolvedPaths, pathInfos = filterOversizedClosures(resolvedPaths, pathInfos, maxNarSize)
+	if len(resolvedPaths) == 0 {
+		slog.Warn("All closures skipped by server max NAR size, nothing to upload")
+
+		return closurePaths, nil
 	}
 
 	// Prepare closures - one per top-level path

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -141,6 +141,10 @@ let
     "--server-url"
     cfg.serverUrl
   ]
+  ++ lib.optionals (cfg.maxNarSize != null) [
+    "--max-nar-size"
+    cfg.maxNarSize
+  ]
   ++ lib.concatMap (f: [
     "--sign-key-path"
     (toString f)
@@ -345,6 +349,16 @@ in
         cache stats from {serverUrl}/api/cache-stats. If unset, the page uses a
         same-origin relative path, which only works when the cache is served by
         niks3 or a proxy that routes /api/cache-stats to it.
+      '';
+    };
+
+    maxNarSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "2G";
+      description = ''
+        Maximum uncompressed NAR size accepted for upload (e.g. "2G", "512M").
+        Clients skip closures containing larger store paths. Null means unlimited.
       '';
     };
 

--- a/nix/packages/niks3-tests.nix
+++ b/nix/packages/niks3-tests.nix
@@ -38,10 +38,14 @@ pkgs.buildGoModule {
   buildPhase = ''
     runHook preBuild
 
-    go test -c ./client -o client.test
-    go test -c ./server -o server.test
-    go test -c ./server/oidc -o server-oidc.test
-    go test -c ./hook -o hook.test
+    # Cap compiler/vet parallelism at the allotted build cores; go defaults to
+    # all CPUs, which exhausts process limits on shared builders.
+    export GOMAXPROCS=$NIX_BUILD_CORES
+
+    go test -c -p "$NIX_BUILD_CORES" ./client -o client.test
+    go test -c -p "$NIX_BUILD_CORES" ./server -o server.test
+    go test -c -p "$NIX_BUILD_CORES" ./server/oidc -o server-oidc.test
+    go test -c -p "$NIX_BUILD_CORES" ./hook -o hook.test
 
     runHook postBuild
   '';

--- a/server/cache_config.go
+++ b/server/cache_config.go
@@ -21,6 +21,7 @@ func (s *Service) CacheConfigHandler(w http.ResponseWriter, r *http.Request) {
 	cfg := api.CacheConfig{
 		SubstituterURL: s.CacheURL,
 		PublicKeys:     make([]string, 0, len(s.SigningKeys)),
+		MaxNarSize:     s.MaxNarSize,
 	}
 
 	for _, key := range s.SigningKeys {

--- a/server/main.go
+++ b/server/main.go
@@ -91,6 +91,8 @@ func (s *stringSliceFlag) Set(value string) error {
 func parseArgs() (*options, error) {
 	var opts options
 
+	maxNarSize := ""
+
 	s3AccessKeyPath := ""
 	s3SecretKeyPath := ""
 	apiTokenPath := ""
@@ -140,6 +142,8 @@ func parseArgs() (*options, error) {
 	flag.StringVar(&opts.TLSKey, "tls-key", getEnvOrDefault("NIKS3_TLS_KEY", ""), "TLS private key")
 	flag.StringVar(&opts.TLSClientCA, "tls-client-ca", getEnvOrDefault("NIKS3_TLS_CLIENT_CA", ""),
 		"CA bundle for native mTLS client cert verification; subjects checked against --mtls-bound-subject")
+	flag.StringVar(&maxNarSize, "max-nar-size", getEnvOrDefault("NIKS3_MAX_NAR_SIZE", ""),
+		"Maximum uncompressed NAR size accepted for upload (e.g. 2G, 512M). Empty or 0 means unlimited")
 	flag.BoolVar(&opts.EnableReadProxy, "enable-read-proxy",
 		getEnvOrDefault("NIKS3_ENABLE_READ_PROXY", "false") == "true",
 		"Serve cache objects by proxying reads from S3 (for private buckets)")
@@ -174,6 +178,10 @@ func parseArgs() (*options, error) {
 
 	if opts.S3BucketLookup, err = parseBucketLookup(s3BucketLookup); err != nil {
 		return nil, err
+	}
+
+	if opts.MaxNarSize, err = ParseSize(maxNarSize); err != nil {
+		return nil, fmt.Errorf("invalid --max-nar-size: %w", err)
 	}
 
 	var secret string

--- a/server/max_nar_size_test.go
+++ b/server/max_nar_size_test.go
@@ -1,0 +1,70 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/api"
+	"github.com/Mic92/niks3/server"
+)
+
+func TestCacheConfigHandlerMaxNarSize(t *testing.T) {
+	t.Parallel()
+
+	s := &server.Service{MaxNarSize: 2 << 30}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/cache-config", nil)
+	rr := httptest.NewRecorder()
+	s.CacheConfigHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var got api.CacheConfig
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.MaxNarSize != 2<<30 {
+		t.Errorf("MaxNarSize = %d, want %d", got.MaxNarSize, 2<<30)
+	}
+}
+
+// Oversized NAR objects are rejected before any DB or S3 work, so a bare
+// Service with only MaxNarSize set is enough for this test.
+func TestCreatePendingClosureRejectsOversizedNAR(t *testing.T) {
+	t.Parallel()
+
+	s := &server.Service{MaxNarSize: 1024}
+
+	closureHash := strings.Repeat("a", 32)
+	narKey := narKeyFor(closureHash)
+
+	body, err := json.Marshal(map[string]any{
+		"closure": closureHash + ".narinfo",
+		"objects": []map[string]any{
+			{"key": closureHash + ".narinfo", "type": "narinfo", "refs": []string{narKey}},
+			{"key": narKey, "type": "nar", "refs": []string{}, "nar_size": 4096},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pending_closures", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.CreatePendingClosureHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+
+	if !strings.Contains(rr.Body.String(), "exceeds server max NAR size") {
+		t.Errorf("unexpected error message: %s", rr.Body.String())
+	}
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -34,6 +34,8 @@ type Metrics struct {
 	gcDuration        prometheus.Histogram
 	gcObjectsDeleted  prometheus.Counter
 	gcLastRun         prometheus.Gauge
+	skippedPaths      prometheus.Counter
+	skippedNarBytes   prometheus.Counter
 }
 
 // NewMetrics builds a registry with the Go/process collectors and the cache
@@ -100,6 +102,14 @@ func NewMetrics() *Metrics {
 			Name: "niks3_gc_last_run_timestamp_seconds",
 			Help: "Unix time of the last successful garbage collection; absent until one completes after startup.",
 		}),
+		skippedPaths: factory.NewCounter(prometheus.CounterOpts{
+			Name: "niks3_upload_skipped_paths_total",
+			Help: "Store paths clients skipped because a closure exceeded the max NAR size.",
+		}),
+		skippedNarBytes: factory.NewCounter(prometheus.CounterOpts{
+			Name: "niks3_upload_skipped_nar_bytes_total",
+			Help: "Uncompressed NAR bytes of store paths clients skipped due to the max NAR size.",
+		}),
 	}
 }
 
@@ -153,6 +163,12 @@ func (m *Metrics) Instrument(next http.Handler) http.Handler {
 // Handler serves the metrics in the Prometheus text format.
 func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
+}
+
+// recordSkippedUploads records store paths a client skipped due to the max NAR size limit.
+func (m *Metrics) recordSkippedUploads(paths, narBytes uint64) {
+	m.skippedPaths.Add(float64(paths))
+	m.skippedNarBytes.Add(float64(narBytes))
 }
 
 func (s *Service) refreshInventory(ctx context.Context) error {

--- a/server/server.go
+++ b/server/server.go
@@ -301,6 +301,7 @@ func runServer(opts *options) error {
 	mux.HandleFunc("POST /api/pending_closures/{id}/complete", service.AuthMiddleware(service.CommitPendingClosureHandler))
 	mux.HandleFunc("POST /api/multipart/complete", service.AuthMiddleware(service.CompleteMultipartUploadHandler))
 	mux.HandleFunc("POST /api/uploads/complete", service.AuthMiddleware(service.CompleteUploadHandler))
+	mux.HandleFunc("POST /api/uploads/skipped", service.AuthMiddleware(service.SkippedUploadsHandler))
 	mux.HandleFunc("POST /api/multipart/request-parts", service.AuthMiddleware(service.RequestMorePartsHandler))
 	mux.HandleFunc("HEAD /api/objects/{key...}", service.AuthMiddleware(service.ObjectExistsHandler))
 	mux.HandleFunc("GET /api/closures/{key}", service.AuthMiddleware(service.GetClosureHandler))

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,10 @@ type options struct {
 	OIDCConfigPath  string
 	EnableReadProxy bool
 
+	// MaxNarSize is the maximum uncompressed NAR size in bytes accepted for
+	// upload. 0 means unlimited.
+	MaxNarSize uint64
+
 	// MTLSProxyHeader, when set, names a header the reverse proxy sets to
 	// "SUCCESS" after verifying a client certificate (e.g. nginx's
 	// $ssl_client_verify). Requests carrying it are accepted without a
@@ -99,6 +103,10 @@ type Service struct {
 	MTLSSubjectHeader     string
 	MTLSBoundSubjects     []string
 	MTLSBoundSubjectsRead []string
+
+	// MaxNarSize is advertised via /api/cache-config and enforced on
+	// pending-closure creation. 0 means unlimited.
+	MaxNarSize uint64
 
 	// NativeMTLS is set when the server terminates TLS itself with a
 	// client CA — mtlsCheck reads r.TLS.PeerCertificates directly
@@ -225,6 +233,7 @@ func runServer(opts *options) error {
 		MTLSBoundSubjectsRead: opts.MTLSBoundSubjectsRead,
 		CacheURL:              opts.CacheURL,
 		ServerURL:             opts.ServerURL,
+		MaxNarSize:            opts.MaxNarSize,
 		GCTasks:               NewGCTaskStore(),
 		Metrics:               NewMetrics(),
 	}

--- a/server/size.go
+++ b/server/size.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseSize parses a byte size like "2G", "512MiB", "100K", or a plain number
+// of bytes. Suffixes are base-1024, case-insensitive, with optional trailing
+// "iB"/"B". Empty string returns 0 (unlimited).
+func ParseSize(value string) (uint64, error) {
+	s := strings.TrimSpace(value)
+	if s == "" {
+		return 0, nil
+	}
+
+	upper := strings.ToUpper(s)
+	upper = strings.TrimSuffix(upper, "IB")
+	upper = strings.TrimSuffix(upper, "B")
+
+	multiplier := uint64(1)
+
+	if len(upper) > 0 {
+		switch upper[len(upper)-1] {
+		case 'K':
+			multiplier = 1 << 10
+		case 'M':
+			multiplier = 1 << 20
+		case 'G':
+			multiplier = 1 << 30
+		case 'T':
+			multiplier = 1 << 40
+		}
+
+		if multiplier > 1 {
+			upper = upper[:len(upper)-1]
+		}
+	}
+
+	num, err := strconv.ParseFloat(strings.TrimSpace(upper), 64)
+	if err != nil || num < 0 {
+		return 0, fmt.Errorf("invalid size %q: expected a number with optional K/M/G/T suffix", value)
+	}
+
+	return uint64(num * float64(multiplier)), nil
+}

--- a/server/size_test.go
+++ b/server/size_test.go
@@ -1,0 +1,51 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/Mic92/niks3/server"
+)
+
+func TestParseSize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want uint64
+		err  bool
+	}{
+		{"", 0, false},
+		{"0", 0, false},
+		{"1024", 1024, false},
+		{"100K", 100 << 10, false},
+		{"512M", 512 << 20, false},
+		{"512MiB", 512 << 20, false},
+		{"2G", 2 << 30, false},
+		{"2g", 2 << 30, false},
+		{"1.5G", 1610612736, false},
+		{"1T", 1 << 40, false},
+		{"abc", 0, true},
+		{"-1G", 0, true},
+	}
+
+	for _, tc := range cases {
+		got, err := server.ParseSize(tc.in)
+		if tc.err {
+			if err == nil {
+				t.Errorf("ParseSize(%q): expected error, got %d", tc.in, got)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("ParseSize(%q): unexpected error: %v", tc.in, err)
+
+			continue
+		}
+
+		if got != tc.want {
+			t.Errorf("ParseSize(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/server/skipped_uploads.go
+++ b/server/skipped_uploads.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+type skippedUploadsRequest struct {
+	Paths    uint64 `json:"paths"`
+	NarBytes uint64 `json:"nar_bytes"`
+}
+
+// SkippedUploadsHandler handles POST /api/uploads/skipped. Clients report
+// store paths they skipped due to the max NAR size limit, so operators can
+// see how much data never reaches the cache via /metrics.
+func (s *Service) SkippedUploadsHandler(w http.ResponseWriter, r *http.Request) {
+	defer closeRequestBody(r)
+
+	req := &skippedUploadsRequest{}
+	if !decodeJSONBody(w, r, maxAPIRequestBody, req) {
+		return
+	}
+
+	s.Metrics.recordSkippedUploads(req.Paths, req.NarBytes)
+	slog.Info("Client skipped oversized paths", "paths", req.Paths, "nar_bytes", req.NarBytes)
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/skipped_uploads_test.go
+++ b/server/skipped_uploads_test.go
@@ -1,0 +1,43 @@
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/server"
+)
+
+func TestSkippedUploadsHandler(t *testing.T) {
+	t.Parallel()
+
+	s := &server.Service{Metrics: server.NewMetrics()}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/uploads/skipped",
+		strings.NewReader(`{"paths": 3, "nar_bytes": 5000000000}`))
+	rr := httptest.NewRecorder()
+	s.SkippedUploadsHandler(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body: %s", rr.Code, rr.Body.String())
+	}
+
+	rec := httptest.NewRecorder()
+	s.Metrics.Handler().ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/metrics", nil))
+
+	body, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("reading metrics: %v", err)
+	}
+
+	for _, want := range []string{
+		"niks3_upload_skipped_paths_total 3",
+		"niks3_upload_skipped_nar_bytes_total 5e+09",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("metrics missing %q", want)
+		}
+	}
+}

--- a/server/uploads.go
+++ b/server/uploads.go
@@ -122,6 +122,15 @@ func (s *Service) CreatePendingClosureHandler(w http.ResponseWriter, r *http.Req
 			return
 		}
 
+		// Advisory size limit: nar_size is client-supplied and optional, the
+		// real filtering happens in the client based on /api/cache-config.
+		if s.MaxNarSize > 0 && object.NarSize != nil && *object.NarSize > s.MaxNarSize {
+			http.Error(w, fmt.Sprintf("NAR object %q size %d exceeds server max NAR size %d bytes",
+				object.Key, *object.NarSize, s.MaxNarSize), http.StatusBadRequest)
+
+			return
+		}
+
 		objectsMap[object.Key] = object
 	}
 


### PR DESCRIPTION
Adds a server-configured upload size limit so large store paths (multi-GB VM images) are not pushed to the cache.

The server takes `--max-nar-size` / `NIKS3_MAX_NAR_SIZE` and advertises it via `GET /api/cache-config`. Pending closures declaring an oversized `nar_size` are rejected as defense in depth.

The client fetches the config on each push and skips any closure containing an oversized path, keeping uploaded closures complete. Skipping warns and exits 0; skipped paths count as handled so the hook queue drains.

The NixOS module gains `services.niks3.maxNarSize`, and the Setup-Guide wiki page is updated.

Closes #443