### PR TITLE
README: remove FileHash/FileSize from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ niks3 implements the [Nix binary cache specification](https://nixos.org/manual/n
 - **NAR files** (`nar/`): Compressed with zstd, stored in S3
 - **Narinfo files** (`.narinfo`): Metadata with cryptographic signatures
   - StorePath, URL, Compression, NarHash, NarSize
-  - FileHash, FileSize (for compressed NAR)
   - References, Deriver
   - Signatures (Sig fields)
   - CA field for content-addressed derivations


### PR DESCRIPTION

nix doesn't need this information. FileHash requires an additional
sha256 sum which is not really needed by anything. NarHash is enough.
