### PR TITLE
server: redirect NAR reads to presigned S3 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ For private S3 buckets, niks3 can proxy read requests
 from Nix clients to S3 using its own credentials. Enable with `--enable-read-proxy`.
 See the [Private S3 Buckets](https://github.com/Mic92/niks3/wiki/Private-S3-Buckets) wiki page.
 
+With `--read-redirect-ttl 15m` NAR requests are answered with a 307 to a
+presigned S3 URL instead of being streamed, so NAR bytes bypass niks3. Narinfos
+and other metadata stay proxied. Note that anyone holding such a URL can fetch
+that object until it expires, regardless of read-proxy authentication.
+
 ## Features
 
 ### Binary Cache Protocol Support

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -133,6 +133,10 @@ let
     ]) cfg.nginx.mtls.boundSubjectsRead
   )
   ++ lib.optional cfg.readProxy.enable "--enable-read-proxy"
+  ++ lib.optionals (cfg.readProxy.redirectTTL != null) [
+    "--read-redirect-ttl"
+    cfg.readProxy.redirectTTL
+  ]
   ++ lib.optionals (cfg.cacheUrl != null) [
     "--cache-url"
     cfg.cacheUrl
@@ -376,6 +380,17 @@ in
 
     readProxy = {
       enable = lib.mkEnableOption "built-in read proxy for serving the cache from a private S3 bucket";
+
+      redirectTTL = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "15m";
+        description = ''
+          Redirect NAR reads to presigned S3 URLs valid for this long instead
+          of streaming them through niks3. Anyone holding such a URL can fetch
+          the object until it expires.
+        '';
+      };
     };
 
     nginx = {

--- a/server/main.go
+++ b/server/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	minio "github.com/minio/minio-go/v7"
 )
@@ -57,6 +58,16 @@ func getEnvOrDefaultFloat(key string, defaultValue float64) float64 {
 	return defaultValue
 }
 
+func getEnvOrDefaultDuration(key string, defaultValue time.Duration) time.Duration {
+	if value, ok := os.LookupEnv(key); ok {
+		if duration, err := time.ParseDuration(value); err == nil {
+			return duration
+		}
+	}
+
+	return defaultValue
+}
+
 func readSecretFile(path string) (string, error) {
 	if path == "" {
 		return "", nil
@@ -73,6 +84,9 @@ func readSecretFile(path string) (string, error) {
 const (
 	minAPITokenLength    = 36
 	defaultS3Concurrency = 100
+
+	// maxReadRedirectTTL is the longest lifetime SigV4 allows a presigned URL.
+	maxReadRedirectTTL = 7 * 24 * time.Hour
 )
 
 // stringSliceFlag implements flag.Value for repeatable string flags.
@@ -84,6 +98,22 @@ func (s *stringSliceFlag) String() string {
 
 func (s *stringSliceFlag) Set(value string) error {
 	*s = append(*s, value)
+
+	return nil
+}
+
+func validateReadRedirect(opts *options) error {
+	if opts.ReadRedirectTTL == 0 {
+		return nil
+	}
+
+	if !opts.EnableReadProxy {
+		return errors.New("--read-redirect-ttl requires --enable-read-proxy")
+	}
+
+	if opts.ReadRedirectTTL < time.Second || opts.ReadRedirectTTL > maxReadRedirectTTL {
+		return fmt.Errorf("--read-redirect-ttl must be between 1s and %s", maxReadRedirectTTL)
+	}
 
 	return nil
 }
@@ -147,6 +177,10 @@ func parseArgs() (*options, error) {
 	flag.BoolVar(&opts.EnableReadProxy, "enable-read-proxy",
 		getEnvOrDefault("NIKS3_ENABLE_READ_PROXY", "false") == "true",
 		"Serve cache objects by proxying reads from S3 (for private buckets)")
+	flag.DurationVar(&opts.ReadRedirectTTL, "read-redirect-ttl",
+		getEnvOrDefaultDuration("NIKS3_READ_REDIRECT_TTL", 0),
+		"Answer NAR reads with a redirect to a presigned S3 URL valid for this long (e.g. 15m) instead of "+
+			"streaming them; requires --enable-read-proxy. 0 disables")
 	flag.BoolVar(&opts.Debug, "debug", getEnvOrDefault("NIKS3_DEBUG", "false") == "true",
 		"Enable debug logging (may leak sensitive information)")
 
@@ -230,6 +264,10 @@ func parseArgs() (*options, error) {
 	// API token is always required (for GC and admin operations)
 	if opts.APIToken == "" {
 		return nil, errors.New("missing required flag: --api-token or --api-token-path")
+	}
+
+	if err := validateReadRedirect(&opts); err != nil {
+		return nil, err
 	}
 
 	if (opts.TLSCert == "") != (opts.TLSKey == "") {

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -240,6 +240,14 @@ func (s *Service) ReadProxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Only NARs redirect: narinfos need decompressing here and the rest is
+	// too small to be worth an extra round trip.
+	if s.ReadRedirectTTL > 0 && narRe.MatchString(key) {
+		s.redirectToS3(w, r, key)
+
+		return
+	}
+
 	// Wait for rate limiter
 	if err := s.S3RateLimiter.Wait(r.Context()); err != nil {
 		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
@@ -254,6 +262,24 @@ func (s *Service) ReadProxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.handleProxyGet(w, r, key)
+}
+
+// redirectToS3 sends the client to a presigned URL for key. Presigning is
+// local; a missing object 404s from S3 rather than from here.
+func (s *Service) redirectToS3(w http.ResponseWriter, r *http.Request, key string) {
+	presigned, err := s.MinioClient.PresignedGetObject(r.Context(), s.Bucket, key, s.ReadRedirectTTL, nil)
+	if err != nil {
+		slog.Error("Failed to presign S3 object", "key", key, "error", err)
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store") // URL expires
+
+	// 307 keeps the method, so HEAD stays HEAD.
+	//nolint:gosec // G710: host comes from config, key is already narrowed to narRe
+	http.Redirect(w, r, presigned.String(), http.StatusTemporaryRedirect)
 }
 
 func (s *Service) handleProxyHead(w http.ResponseWriter, r *http.Request, key string) {

--- a/server/proxy_test.go
+++ b/server/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -396,6 +397,95 @@ func TestReadProxyDisabled(t *testing.T) {
 	defer ts.Close()
 
 	proxyGet(t, ts, "/26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", http.StatusNotFound)
+}
+
+func TestReadRedirectNar(t *testing.T) {
+	t.Parallel()
+
+	service := createProxyTestService(t)
+	service.ReadRedirectTTL = time.Minute
+
+	defer service.Close()
+
+	ctx := t.Context()
+
+	narContent := bytes.Repeat([]byte("x"), 1024*64)
+	key := "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar.zst"
+	putTestObject(ctx, t, service, key, narContent,
+		minio.PutObjectOptions{ContentType: "application/x-nix-nar"})
+
+	ts := setupProxyServer(t, service)
+	defer ts.Close()
+
+	noFollow := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		req, err := http.NewRequestWithContext(ctx, method, ts.URL+"/"+key, nil)
+		ok(t, err)
+
+		resp, err := noFollow.Do(req)
+		ok(t, err)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusTemporaryRedirect {
+			t.Fatalf("%s: status = %d, want 307", method, resp.StatusCode)
+		}
+
+		if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+			t.Errorf("%s: Cache-Control = %q, want no-store", method, got)
+		}
+
+		location, err := url.Parse(resp.Header.Get("Location"))
+		ok(t, err)
+
+		if location.Query().Get("X-Amz-Signature") == "" {
+			t.Errorf("%s: Location is not presigned: %s", method, location)
+		}
+
+		if location.Host == req.Host {
+			t.Errorf("%s: Location points back at the proxy: %s", method, location)
+		}
+	}
+
+	// Following the redirect proves S3 accepts the signature.
+	_, body := proxyGet(t, ts, "/"+key, http.StatusOK)
+
+	if !bytes.Equal(body, narContent) {
+		t.Errorf("body mismatch: got %d bytes, want %d", len(body), len(narContent))
+	}
+}
+
+// Narinfos are stored zstd-compressed and must still be decompressed by the proxy.
+func TestReadRedirectKeepsNarinfoProxied(t *testing.T) {
+	t.Parallel()
+
+	service := createProxyTestService(t)
+	service.ReadRedirectTTL = time.Minute
+
+	defer service.Close()
+
+	ctx := t.Context()
+
+	plainNarinfo := []byte("StorePath: /nix/store/abc123-hello\nURL: nar/abc.nar.zst\n")
+	putTestObject(ctx, t, service, "26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", zstdCompress(t, plainNarinfo),
+		minio.PutObjectOptions{ContentType: "application/x-nix-narinfo", ContentEncoding: "zstd"})
+
+	ts := setupProxyServer(t, service)
+	defer ts.Close()
+
+	header, body := proxyGet(t, ts, "/26xbg1ndr7hbcncrlf9nhx5is2b25d13.narinfo", http.StatusOK)
+
+	if !bytes.Equal(body, plainNarinfo) {
+		t.Errorf("body mismatch: got %q, want %q", body, plainNarinfo)
+	}
+
+	if got := header.Get("Cache-Control"); got == "no-store" {
+		t.Error("narinfo was redirected, want proxied")
+	}
 }
 
 // TestReadProxyRangeRequest ensures the proxy honors Range headers so an

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,10 @@ type options struct {
 	OIDCConfigPath  string
 	EnableReadProxy bool
 
+	// ReadRedirectTTL > 0 redirects NAR reads to presigned S3 URLs with this
+	// lifetime instead of streaming them. Requires EnableReadProxy.
+	ReadRedirectTTL time.Duration
+
 	// MaxNarSize is the maximum uncompressed NAR size in bytes accepted for
 	// upload. 0 means unlimited.
 	MaxNarSize uint64
@@ -103,6 +107,9 @@ type Service struct {
 	MTLSSubjectHeader     string
 	MTLSBoundSubjects     []string
 	MTLSBoundSubjectsRead []string
+
+	// See options.ReadRedirectTTL.
+	ReadRedirectTTL time.Duration
 
 	// MaxNarSize is advertised via /api/cache-config and enforced on
 	// pending-closure creation. 0 means unlimited.
@@ -313,10 +320,15 @@ func runServer(opts *options) error {
 
 	if opts.EnableReadProxy {
 		service.EnableReadProxy = true
+		service.ReadRedirectTTL = opts.ReadRedirectTTL
 		// Register without method prefix to avoid ServeMux conflicts with
 		// auto-generated HEAD routes. The handler rejects non-GET/HEAD itself.
 		mux.HandleFunc("/{path...}", service.ReadAuthMiddleware(service.ReadProxyHandler))
 		slog.Info("Read proxy enabled — serving cache objects from S3")
+
+		if opts.ReadRedirectTTL > 0 {
+			slog.Info("NAR reads redirect to presigned S3 URLs", "ttl", opts.ReadRedirectTTL)
+		}
 	} else {
 		mux.HandleFunc("GET /", service.RootRedirectHandler)
 	}


### PR DESCRIPTION
`--read-redirect-ttl 15m` makes the read proxy answer NAR requests with a 307 to a presigned S3 URL instead of streaming the object, so NAR bytes never pass through niks3. Off by default; requires `--enable-read-proxy`.

Only `nar/*` redirects. Narinfos stay proxied since they are stored zstd-compressed and decompressed here, and the rest of the metadata is small enough that an extra round trip costs more than proxying it. Nix follows the redirect (`CURLOPT_FOLLOWLOCATION`) and sends no netrc credentials to the target, since curl matches netrc per host.

Redirected reads make no S3 request at all — presigning is local, and the `StatObject` existence check goes away with it, so a missing object 404s from S3 after the redirect rather than from here.

Two tradeoffs, both noted in the README next to the flag: each redirect hands out a bounded-lifetime capability URL for one object, usable without whatever gates the read proxy sits behind; and NAR reads stop passing through the adaptive S3 rate limiter.

`TestReadRedirectNar` follows the presigned URL through to the object and checks that HEAD redirects too; `TestReadRedirectKeepsNarinfoProxied` guards the carve-out. Full `./server/...` suite passes, with no new golangci-lint findings against the base commit.
