### PR TITLE
client: add upstream cache filtering

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	Retry                   RetryConfig                    // Retry configuration for HTTP requests
 	storeDir                string                         // Cached Nix store directory (e.g., "/nix/store")
 	VerifyS3Integrity       bool                           // Enable S3 integrity checking when creating pending closures
+	UpstreamCacheKeyNames   []string                       // Signing key names whose paths are available from upstream caches
 	DebugHTTP               bool                           // Enable HTTP request/response debug logging
 	S3RateLimiter           *ratelimit.AdaptiveRateLimiter // Rate limiter for S3 presigned URL uploads
 	ServerRateLimiter       *ratelimit.AdaptiveRateLimiter // Rate limiter for niks3 server API calls

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -21,6 +21,9 @@ var PartSizeForNAR = partSizeForNAR //nolint:gochecknoglobals // test-only re-ex
 // FilterOversizedClosures re-exports filterOversizedClosures for the external test package.
 var FilterOversizedClosures = filterOversizedClosures //nolint:gochecknoglobals // test-only re-export
 
+// FilterUpstreamClosure re-exports filterUpstreamClosure for the external test package.
+var FilterUpstreamClosure = filterUpstreamClosure //nolint:gochecknoglobals // test-only re-export
+
 // MultipartPartSize re-exports the default part size for tests.
 const MultipartPartSize = multipartPartSize
 

--- a/client/nixstore.go
+++ b/client/nixstore.go
@@ -222,8 +222,8 @@ type RealisationInfo struct {
 
 // GetPathInfoRecursive queries Nix for path info including all dependencies.
 func GetPathInfoRecursive(ctx context.Context, storePaths []string, nixEnv []string) (map[string]*PathInfo, error) {
-	args := make([]string, 0, 6+len(storePaths))
-	args = append(args, "--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--")
+	args := make([]string, 0, 7+len(storePaths))
+	args = append(args, "--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--sigs", "--")
 	args = append(args, storePaths...)
 
 	cmd := exec.CommandContext(ctx, "nix", args...)

--- a/client/upload.go
+++ b/client/upload.go
@@ -313,6 +313,108 @@ type skippedUploads struct {
 	NarBytes uint64
 }
 
+// upstreamFilterStats counts paths omitted because a signed upstream path
+// makes that path and its dependency subtree available elsewhere.
+type upstreamFilterStats struct {
+	Paths    uint64
+	NarBytes uint64
+}
+
+func signedByUpstream(pathInfo *PathInfo, keyNames map[string]struct{}) bool {
+	for _, signature := range pathInfo.Signatures {
+		name, _, ok := strings.Cut(signature, ":")
+		if !ok {
+			continue
+		}
+
+		if _, ok := keyNames[name]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterUpstreamClosure removes paths signed by a configured upstream cache.
+// A matching path is a traversal boundary: its dependencies are expected to be
+// available from the same upstream and must not become unreachable objects in
+// niks3's local GC graph.
+func filterUpstreamClosure(
+	topLevelPaths []string,
+	pathInfos map[string]*PathInfo,
+	upstreamCacheKeyNames []string,
+) ([]string, map[string]*PathInfo, upstreamFilterStats) {
+	if len(upstreamCacheKeyNames) == 0 || len(pathInfos) == 0 {
+		return topLevelPaths, pathInfos, upstreamFilterStats{}
+	}
+
+	keyNames := make(map[string]struct{}, len(upstreamCacheKeyNames))
+
+	for _, name := range upstreamCacheKeyNames {
+		keyNames[name] = struct{}{}
+	}
+
+	upstreamPaths := make(map[string]bool)
+
+	for path, pathInfo := range pathInfos {
+		if signedByUpstream(pathInfo, keyNames) {
+			upstreamPaths[path] = true
+		}
+	}
+
+	if len(upstreamPaths) == 0 {
+		return topLevelPaths, pathInfos, upstreamFilterStats{}
+	}
+
+	keptRoots := make([]string, 0, len(topLevelPaths))
+	for _, path := range topLevelPaths {
+		if !upstreamPaths[path] {
+			keptRoots = append(keptRoots, path)
+		}
+	}
+
+	reachable := make(map[string]bool)
+
+	var visit func(string)
+
+	visit = func(path string) {
+		if reachable[path] || upstreamPaths[path] {
+			return
+		}
+
+		pathInfo, ok := pathInfos[path]
+		if !ok {
+			return
+		}
+
+		reachable[path] = true
+
+		for _, ref := range pathInfo.References {
+			visit(ref)
+		}
+	}
+
+	for _, path := range keptRoots {
+		visit(path)
+	}
+
+	prunedInfos := make(map[string]*PathInfo, len(reachable))
+	for path := range reachable {
+		prunedInfos[path] = pathInfos[path]
+	}
+
+	var filtered upstreamFilterStats
+
+	for path, pathInfo := range pathInfos {
+		if !reachable[path] {
+			filtered.Paths++
+			filtered.NarBytes += pathInfo.NarSize
+		}
+	}
+
+	return keptRoots, prunedInfos, filtered
+}
+
 // filterOversizedClosures drops top-level paths whose closure contains a path
 // with NarSize larger than maxNarSize. A limit of 0 disables filtering. It returns the kept
 // top-level paths, pathInfos pruned to paths still reachable from them, and
@@ -526,11 +628,29 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 	slog.Debug("Found paths in closure", "count", len(pathInfos))
 
 	// Collect all closure paths to return to the caller. This includes paths
-	// from closures skipped by the size filter below, so callers (e.g. the
-	// hook queue) treat them as handled instead of retrying forever.
+	// omitted by the filters below, so callers (e.g. the hook queue) treat them
+	// as handled instead of retrying forever.
 	closurePaths := make([]string, 0, len(pathInfos))
 	for storePath := range pathInfos {
 		closurePaths = append(closurePaths, storePath)
+	}
+
+	var upstreamFiltered upstreamFilterStats
+
+	if len(c.UpstreamCacheKeyNames) > 0 {
+		resolvedPaths, pathInfos, upstreamFiltered = filterUpstreamClosure(
+			resolvedPaths,
+			pathInfos,
+			c.UpstreamCacheKeyNames,
+		)
+	}
+
+	if len(resolvedPaths) == 0 {
+		slog.Info("All paths available from configured upstream caches, nothing to upload",
+			"paths", upstreamFiltered.Paths,
+			"nar_bytes", upstreamFiltered.NarBytes)
+
+		return closurePaths, nil
 	}
 
 	// Skip closures containing paths larger than the server's max NAR size.
@@ -586,7 +706,8 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 
 	cachedPaths := len(pathInfos) - newPaths
 
-	slog.Info(fmt.Sprintf("Uploading %d paths to %s (%d already cached)", newPaths, c.baseURL.Hostname(), cachedPaths))
+	slog.Info(fmt.Sprintf("Uploading %d paths to %s (%d already cached, %d in upstream)",
+		newPaths, c.baseURL.Hostname(), cachedPaths, upstreamFiltered.Paths))
 	slog.Debug("Need to upload objects", "pending", len(pendingObjects), "closures", len(closureIDToNarinfoKey))
 
 	// Upload all pending objects and collect narinfo metadata

--- a/client/upstream_filter_test.go
+++ b/client/upstream_filter_test.go
@@ -1,0 +1,161 @@
+package client_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+func TestFilterUpstreamClosure(t *testing.T) {
+	t.Parallel()
+
+	const store = "/nix/store/"
+
+	root := store + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-root"
+	upstream := store + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-upstream"
+	upstreamDependency := store + "cccccccccccccccccccccccccccccccc-upstream-dependency"
+	localDependency := store + "dddddddddddddddddddddddddddddddd-local-dependency"
+
+	pathInfos := map[string]*client.PathInfo{
+		root: {
+			Path:       root,
+			NarSize:    100,
+			References: []string{upstream, localDependency},
+		},
+		upstream: {
+			Path:       upstream,
+			NarSize:    200,
+			References: []string{upstreamDependency},
+			Signatures: []string{"cache.nixos.org-1:signature"},
+		},
+		upstreamDependency: {
+			Path:    upstreamDependency,
+			NarSize: 300,
+		},
+		localDependency: {
+			Path:    localDependency,
+			NarSize: 400,
+		},
+	}
+
+	t.Run("empty configuration disables filtering", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure([]string{root}, pathInfos, nil)
+		if !slices.Equal(roots, []string{root}) || len(infos) != len(pathInfos) {
+			t.Fatalf("roots = %v, infos = %d, want unchanged closure", roots, len(infos))
+		}
+
+		if filtered.Paths != 0 || filtered.NarBytes != 0 {
+			t.Errorf("filtered = %+v, want none", filtered)
+		}
+	})
+
+	t.Run("signed path cuts its dependency subtree", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure(
+			[]string{root},
+			pathInfos,
+			[]string{"cache.nixos.org-1"},
+		)
+		if !slices.Equal(roots, []string{root}) {
+			t.Fatalf("roots = %v, want only %s", roots, root)
+		}
+
+		if len(infos) != 2 || infos[root] == nil || infos[localDependency] == nil {
+			t.Errorf("infos = %v, want root and local dependency", infos)
+		}
+
+		if filtered.Paths != 2 || filtered.NarBytes != 500 {
+			t.Errorf("filtered = %+v, want 2 paths / 500 bytes", filtered)
+		}
+	})
+
+	t.Run("separate root keeps a path below an upstream boundary", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure(
+			[]string{root, upstreamDependency},
+			pathInfos,
+			[]string{"cache.nixos.org-1"},
+		)
+		if !slices.Equal(roots, []string{root, upstreamDependency}) {
+			t.Fatalf("roots = %v, want both local roots", roots)
+		}
+
+		if len(infos) != 3 || infos[upstream] != nil {
+			t.Errorf("infos = %v, want every path except signed upstream", infos)
+		}
+
+		if filtered.Paths != 1 || filtered.NarBytes != 200 {
+			t.Errorf("filtered = %+v, want 1 path / 200 bytes", filtered)
+		}
+	})
+
+	t.Run("signed root removes its whole closure", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure(
+			[]string{upstream},
+			map[string]*client.PathInfo{
+				upstream:           pathInfos[upstream],
+				upstreamDependency: pathInfos[upstreamDependency],
+			},
+			[]string{"cache.nixos.org-1"},
+		)
+		if len(roots) != 0 || len(infos) != 0 {
+			t.Fatalf("roots = %v, infos = %v, want empty closure", roots, infos)
+		}
+
+		if filtered.Paths != 2 || filtered.NarBytes != 500 {
+			t.Errorf("filtered = %+v, want 2 paths / 500 bytes", filtered)
+		}
+	})
+
+	t.Run("key names match exactly", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure(
+			[]string{upstream},
+			map[string]*client.PathInfo{
+				upstream: {
+					Path:       upstream,
+					Signatures: []string{"cache.nixos.org-10:signature", "malformed"},
+				},
+			},
+			[]string{"cache.nixos.org-1"},
+		)
+		if !slices.Equal(roots, []string{upstream}) || len(infos) != 1 {
+			t.Fatalf("roots = %v, infos = %v, want unchanged closure", roots, infos)
+		}
+
+		if filtered.Paths != 0 {
+			t.Errorf("filtered = %+v, want none", filtered)
+		}
+	})
+
+	t.Run("any configured key can match", func(t *testing.T) {
+		t.Parallel()
+
+		roots, infos, filtered := client.FilterUpstreamClosure(
+			[]string{upstream},
+			map[string]*client.PathInfo{
+				upstream: {
+					Path:       upstream,
+					NarSize:    200,
+					Signatures: []string{"example.org-1:signature"},
+				},
+			},
+			[]string{"cache.nixos.org-1", "example.org-1"},
+		)
+		if len(roots) != 0 || len(infos) != 0 {
+			t.Fatalf("roots = %v, infos = %v, want filtered closure", roots, infos)
+		}
+
+		if filtered.Paths != 1 || filtered.NarBytes != 200 {
+			t.Errorf("filtered = %+v, want 1 path / 200 bytes", filtered)
+		}
+	})
+}

--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -67,6 +67,8 @@ func printServeHelp() {
 	fmt.Fprintln(os.Stderr, "        Concurrent upload limit (default: 30)")
 	fmt.Fprintln(os.Stderr, "  --verify-s3-integrity")
 	fmt.Fprintln(os.Stderr, "        Verify S3 objects before skipping")
+	fmt.Fprintln(os.Stderr, "  --upstream-cache-key-name string")
+	fmt.Fprintln(os.Stderr, "        Upstream cache signing key name; repeat to specify multiple names")
 	fmt.Fprintln(os.Stderr, cmdutil.TLSHelp)
 	fmt.Fprintln(os.Stderr, "  --debug")
 	fmt.Fprintln(os.Stderr, "        Enable debug logging")
@@ -143,6 +145,7 @@ func runServe() error {
 	idleExitTimeout := fs.String("idle-exit-timeout", "60s", "Exit after no activity; \"0\" to disable")
 	maxConcurrent := fs.Int("max-concurrent-uploads", 30, "Concurrent upload limit")
 	verifyS3 := fs.Bool("verify-s3-integrity", false, "Verify S3 integrity")
+	upstreamCacheKeyNames := cmdutil.AddUpstreamCacheKeyNameFlag(fs)
 	tf := cmdutil.AddTLSFlags(fs)
 
 	ts, err := cmdutil.ParseCommand(fs, cf, tf, os.Args[2:], printServeHelp)
@@ -187,6 +190,7 @@ func runServe() error {
 
 	c.MaxConcurrentNARUploads = *maxConcurrent
 	c.VerifyS3Integrity = *verifyS3
+	c.UpstreamCacheKeyNames = *upstreamCacheKeyNames
 
 	// Notification channels: the server notifies both the worker and the
 	// idle timer when new paths are queued. Separate channels avoid the

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -47,6 +47,8 @@ func printPushHelp() {
 	fmt.Fprintln(os.Stderr, "        Maximum concurrent uploads (default: 30)")
 	fmt.Fprintln(os.Stderr, "  --verify-s3-integrity")
 	fmt.Fprintln(os.Stderr, "        Verify that objects in database actually exist in S3 before skipping upload")
+	fmt.Fprintln(os.Stderr, "  --upstream-cache-key-name string")
+	fmt.Fprintln(os.Stderr, "        Upstream cache signing key name; repeat to specify multiple names")
 	fmt.Fprintln(os.Stderr, cmdutil.TLSHelp)
 	fmt.Fprintln(os.Stderr, "  --debug")
 	fmt.Fprintln(os.Stderr, "        Enable debug logging (includes HTTP requests/responses)")
@@ -96,6 +98,7 @@ func run() error {
 		cf := cmdutil.AddCommonFlags(pushCmd)
 		maxConcurrent := pushCmd.Int("max-concurrent-uploads", 30, "Maximum concurrent uploads")
 		verifyS3Integrity := pushCmd.Bool("verify-s3-integrity", false, "Verify S3 integrity")
+		upstreamCacheKeyNames := cmdutil.AddUpstreamCacheKeyNameFlag(pushCmd)
 		pinName := pushCmd.String("pin", "", "Create a named pin for the pushed closure")
 		tf := cmdutil.AddTLSFlags(pushCmd)
 
@@ -113,7 +116,12 @@ func run() error {
 			return errors.New("--pin requires exactly one store path")
 		}
 
-		return pushCommand(*cf.ServerURL, ts, paths, *maxConcurrent, *verifyS3Integrity, *pinName, *cf.Debug, tf)
+		if *pinName != "" && len(*upstreamCacheKeyNames) > 0 {
+			return errors.New("--pin combined with --upstream-cache-key-name is not supported")
+		}
+
+		return pushCommand(*cf.ServerURL, ts, paths, *maxConcurrent, *verifyS3Integrity,
+			*upstreamCacheKeyNames, *pinName, *cf.Debug, tf)
 
 	case "gc":
 		gcCmd := flag.NewFlagSet("gc", flag.ContinueOnError)
@@ -176,7 +184,7 @@ func run() error {
 	}
 }
 
-func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxConcurrent int, verifyS3Integrity bool, pinName string, debug bool, tf cmdutil.TLSFlags) error {
+func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxConcurrent int, verifyS3Integrity bool, upstreamCacheKeyNames []string, pinName string, debug bool, tf cmdutil.TLSFlags) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -191,6 +199,7 @@ func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxCon
 
 	c.MaxConcurrentNARUploads = maxConcurrent
 	c.VerifyS3Integrity = verifyS3Integrity
+	c.UpstreamCacheKeyNames = upstreamCacheKeyNames
 
 	if _, err := c.PushPaths(ctx, paths); err != nil {
 		return fmt.Errorf("pushing paths: %w", err)

--- a/cmdutil/cmdutil.go
+++ b/cmdutil/cmdutil.go
@@ -10,9 +10,33 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Mic92/niks3/client"
 )
+
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return strings.Join(*s, ", ")
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+
+	return nil
+}
+
+// AddUpstreamCacheKeyNameFlag registers the repeatable upstream cache filter
+// shared by interactive pushes and the upload daemon.
+func AddUpstreamCacheKeyNameFlag(fs *flag.FlagSet) *[]string {
+	var keyNames []string
+
+	fs.Var((*stringSliceFlag)(&keyNames), "upstream-cache-key-name",
+		"Upstream cache signing key name; repeat to specify multiple names")
+
+	return &keyNames
+}
 
 // SetupLogger configures the global slog logger with the specified level.
 func SetupLogger(debug bool) {

--- a/cmdutil/cmdutil_test.go
+++ b/cmdutil/cmdutil_test.go
@@ -1,0 +1,51 @@
+package cmdutil_test
+
+import (
+	"flag"
+	"slices"
+	"testing"
+
+	"github.com/Mic92/niks3/cmdutil"
+)
+
+func TestAddUpstreamCacheKeyNameFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{name: "omitted", args: nil, want: nil},
+		{
+			name: "one key",
+			args: []string{"--upstream-cache-key-name", "cache.nixos.org-1"},
+			want: []string{"cache.nixos.org-1"},
+		},
+		{
+			name: "repeated",
+			args: []string{
+				"--upstream-cache-key-name", "cache.nixos.org-1",
+				"--upstream-cache-key-name", "example.org-1",
+			},
+			want: []string{"cache.nixos.org-1", "example.org-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			got := cmdutil.AddUpstreamCacheKeyNameFlag(fs)
+
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("Parse(%v): %v", tt.args, err)
+			}
+
+			if !slices.Equal(*got, tt.want) {
+				t.Errorf("key names = %v, want %v", *got, tt.want)
+			}
+		})
+	}
+}

--- a/nix/darwinModules/niks3-auto-upload.nix
+++ b/nix/darwinModules/niks3-auto-upload.nix
@@ -78,6 +78,20 @@ in
       description = "Verify that objects in database actually exist in S3 before skipping upload.";
     };
 
+    upstreamCacheKeyNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Signing key names for upstream caches. Paths signed by one of these
+        keys, including their dependency subtrees, are not uploaded. Upstream
+        filtering is disabled by default.
+      '';
+      example = [
+        "cache.nixos.org-1"
+        "example.org-1"
+      ];
+    };
+
     debug = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -144,6 +158,10 @@ in
             "--db-path"
             dbPath
           ]
+          ++ lib.concatMap (keyName: [
+            "--upstream-cache-key-name"
+            keyName
+          ]) cfg.upstreamCacheKeyNames
           ++ lib.optional cfg.verifyS3Integrity "--verify-s3-integrity"
           ++ lib.optional cfg.debug "--debug"
           ++ lib.optionals cfg.mtls.enable [

--- a/nix/nixosModules/niks3-auto-upload.nix
+++ b/nix/nixosModules/niks3-auto-upload.nix
@@ -70,6 +70,19 @@ in
       description = "Verify that objects in database actually exist in S3 before skipping upload.";
     };
 
+    upstreamCacheKeyNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Signing key names for upstream caches. Paths signed by one of these
+        keys, including their dependency subtrees, are not uploaded.
+      '';
+      example = [
+        "cache.nixos.org-1"
+        "example.org-1"
+      ];
+    };
+
     debug = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -153,6 +166,10 @@ in
               "--db-path"
               "/var/lib/niks3-hook/upload-queue.db"
             ]
+            ++ lib.concatMap (keyName: [
+              "--upstream-cache-key-name"
+              (lib.escapeShellArg keyName)
+            ]) cfg.upstreamCacheKeyNames
             ++ lib.optional cfg.verifyS3Integrity "--verify-s3-integrity"
             ++ lib.optional cfg.debug "--debug"
             ++ lib.optionals cfg.mtls.enable [

--- a/server/upstream_gc_test.go
+++ b/server/upstream_gc_test.go
@@ -1,0 +1,72 @@
+package server_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/server/pg"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestGCMissingUpstreamReference(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	ctx := t.Context()
+	queries := pg.New(service.Pool)
+
+	rootKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.narinfo"
+	narKey := "nar/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.nar.zst"
+	upstreamKey := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.narinfo"
+
+	pending, err := queries.InsertPendingClosure(ctx, rootKey)
+	ok(t, err)
+
+	_, err = queries.InsertPendingObjects(ctx, []pg.InsertPendingObjectsParams{
+		{PendingClosureID: pending.ID, Key: rootKey, Refs: []string{narKey, upstreamKey}},
+		{PendingClosureID: pending.ID, Key: narKey, Refs: []string{}},
+	})
+	ok(t, err)
+	ok(t, queries.CommitPendingClosure(ctx, pending.ID))
+
+	// A reference to an object served only by an upstream cache stops the
+	// recursive join, while the local root and its NAR remain reachable.
+	_, err = queries.MarkStaleObjects(ctx)
+	ok(t, err)
+
+	var marked int
+
+	err = service.Pool.QueryRow(ctx,
+		"SELECT count(*) FROM objects WHERE deleted_at IS NOT NULL").Scan(&marked)
+	ok(t, err)
+
+	if marked != 0 {
+		t.Fatalf("marked objects = %d, want none while closure is active", marked)
+	}
+
+	objects, err := queries.GetClosureObjects(ctx, rootKey)
+	ok(t, err)
+
+	if len(objects) != 2 {
+		t.Fatalf("reachable objects = %v, want only local root and NAR", objects)
+	}
+
+	_, err = queries.DeleteClosures(ctx, pgtype.Timestamp{
+		Time:  time.Now().UTC().Add(time.Hour),
+		Valid: true,
+	})
+	ok(t, err)
+
+	_, err = queries.MarkStaleObjects(ctx)
+	ok(t, err)
+
+	err = service.Pool.QueryRow(ctx,
+		"SELECT count(*) FROM objects WHERE deleted_at IS NOT NULL").Scan(&marked)
+	ok(t, err)
+
+	if marked != 2 {
+		t.Fatalf("marked objects = %d, want both local objects after closure deletion", marked)
+	}
+}


### PR DESCRIPTION
## Summary

This PR intoduces **upstream cache filtering** (also known as **upstream deduplication**), inspired by [zhaofengli/attic](https://github.com/zhaofengli/attic).

When pushing some closures to server, we filter out path infos by configured list of signature names specified by `--upstream-cache-key-names`, consider them as already available in upstream and only push those not present in upstream to server.

This could be beneficial for cost-sensitive setups, e.g. self-hosting.

## Design

We only check cache key names, [same as attic](https://github.com/zhaofengli/attic/blob/7a19204df10d606c5070e6bb72615c3461900c05/client/src/push.rs#L449-L465). We trust what local nix store provides and perform no further verification.

Attic configures upstreams on server side, and applies filtering on client side. This implementation chooses a pure client-side implementation, as the server doesn't actually involve in the filtering, it is completely up to client what to push to server.

Attic traverses the whole closure graph and filters the paths individually. Its GC tracks each path individually as well.

We perform a DFS, discard all matched store paths, and push the still-reachable paths.

Nix guarantees that the graph is a DAG w/ potential self-references, see [Store Object](https://nix.dev/manual/nix/2.35/store/store-object.html)

```
A -> B (in upstream) -> C
```

Attic will push `A C`, while ours will only push `A`. This is necessary as reference-tracking GC will otherwise lose C.

For binary caches with proper GC setup, we may assume C is kept-alive by B so C is implicitly considered as also available in upstream.

Combing filtering with pinning is currently rejected, as it is hard to justify pinning semantics and decide what to push when they mix together.

## Disclosure

This PR is assisted by codex.