### PR TITLE
hook: do not let one failing path stall the upload queue

### DIFF
--- a/hook/queue.go
+++ b/hook/queue.go
@@ -119,24 +119,43 @@ func (q *Queue) FetchBatch(batchSize int) ([]string, error) {
 	return paths, nil
 }
 
+// removeChunk stays well below SQLite's bound parameter limit (32766); the
+// worker removes whole closures, which can be larger than that.
+const removeChunk = 1000
+
 // Remove deletes the given store paths from the queue.
 func (q *Queue) Remove(paths []string) error {
 	if len(paths) == 0 {
 		return nil
 	}
 
-	// Build a single DELETE ... WHERE store_path IN (...) for efficiency.
-	placeholders := make([]string, len(paths))
-	args := make([]any, len(paths))
+	ctx := context.Background()
 
-	for i, p := range paths {
-		placeholders[i] = "?"
-		args[i] = p
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
 	}
 
-	query := "DELETE FROM upload_queue WHERE store_path IN (" + strings.Join(placeholders, ",") + ")" //nolint:gosec // placeholders are all "?", no injection
-	if _, err := q.db.ExecContext(context.Background(), query, args...); err != nil {
-		return fmt.Errorf("deleting paths: %w", err)
+	defer func() { _ = tx.Rollback() }()
+
+	for len(paths) > 0 {
+		n := min(len(paths), removeChunk)
+		chunk := paths[:n]
+		paths = paths[n:]
+
+		args := make([]any, n)
+		for i, p := range chunk {
+			args[i] = p
+		}
+
+		query := "DELETE FROM upload_queue WHERE store_path IN (?" + strings.Repeat(",?", n-1) + ")" //nolint:gosec // only "?" placeholders
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("deleting paths: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
 	}
 
 	return nil

--- a/hook/queue.go
+++ b/hook/queue.go
@@ -86,11 +86,13 @@ func (q *Queue) Enqueue(paths []string) error {
 	return nil
 }
 
-// FetchBatch returns up to batchSize of the oldest queued store paths.
+// FetchBatch returns up to batchSize store paths from the head of the queue.
+// rowid rather than created_at (second resolution) gives the strict order
+// Retry relies on.
 func (q *Queue) FetchBatch(batchSize int) ([]string, error) {
 	rows, err := q.db.QueryContext(
 		context.Background(),
-		"SELECT store_path FROM upload_queue ORDER BY created_at LIMIT ?",
+		"SELECT store_path FROM upload_queue ORDER BY rowid LIMIT ?",
 		batchSize,
 	)
 	if err != nil {
@@ -135,6 +137,34 @@ func (q *Queue) Remove(paths []string) error {
 	query := "DELETE FROM upload_queue WHERE store_path IN (" + strings.Join(placeholders, ",") + ")" //nolint:gosec // placeholders are all "?", no injection
 	if _, err := q.db.ExecContext(context.Background(), query, args...); err != nil {
 		return fmt.Errorf("deleting paths: %w", err)
+	}
+
+	return nil
+}
+
+// Retry moves paths whose upload failed to the back of the queue so that one
+// bad path cannot block the head. As a consequence everything already tried
+// sorts behind everything untried.
+func (q *Queue) Retry(paths []string) error {
+	ctx := context.Background()
+
+	tx, err := q.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
+	defer func() { _ = tx.Rollback() }()
+
+	for _, p := range paths {
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE upload_queue SET rowid = (SELECT MAX(rowid) FROM upload_queue) + 1 WHERE store_path = ?", p,
+		); err != nil {
+			return fmt.Errorf("requeueing path %q: %w", p, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
 	}
 
 	return nil

--- a/hook/queue_test.go
+++ b/hook/queue_test.go
@@ -3,6 +3,7 @@ package hook_test
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"sync"
 	"testing"
@@ -127,6 +128,30 @@ func TestQueueFetchBatchLimit(t *testing.T) {
 
 	if len(fetched) != 2 {
 		t.Errorf("expected 2, got %d", len(fetched))
+	}
+}
+
+func TestQueueRetryMovesToBack(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+
+	if err := q.Enqueue([]string{"/nix/store/aaa", "/nix/store/bbb", "/nix/store/ccc"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := q.Retry([]string{"/nix/store/aaa"}); err != nil {
+		t.Fatal(err)
+	}
+
+	fetched, err := q.FetchBatch(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"/nix/store/bbb", "/nix/store/ccc", "/nix/store/aaa"}
+	if !slices.Equal(fetched, want) {
+		t.Errorf("got %v, want %v", fetched, want)
 	}
 }
 

--- a/hook/queue_test.go
+++ b/hook/queue_test.go
@@ -236,3 +236,28 @@ func TestQueueConcurrentWriters(t *testing.T) {
 		t.Errorf("expected %d, got %d", writers*perWriter, count)
 	}
 }
+
+// PushPaths returns whole closures, which can exceed SQLite's bound
+// parameter limit (32766) if deleted in a single statement.
+func TestQueueRemoveLargeClosure(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+
+	paths := make([]string, 40000)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("/nix/store/%05d", i)
+	}
+
+	if err := q.Enqueue(paths[:10]); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := q.Remove(paths); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if count, _ := q.Count(); count != 0 {
+		t.Errorf("expected empty queue, got %d", count)
+	}
+}

--- a/hook/worker.go
+++ b/hook/worker.go
@@ -14,6 +14,9 @@ const (
 	initialBackoff      = 1 * time.Second
 	defaultBatchSize    = 50
 	queueLogInterval    = 30 * time.Second
+	// isolationProbes is how many paths of a failed batch are tried on their
+	// own before concluding the server, not the paths, is the problem.
+	isolationProbes = 3
 )
 
 // PushFunc is called by the worker to upload store paths. It returns the
@@ -46,124 +49,6 @@ func NewWorker(queue *Queue, push PushFunc, batchSize int, notify <-chan struct{
 	}
 }
 
-// Run processes the queue until ctx is cancelled. It finishes any in-flight
-// upload before returning.
-func (w *Worker) Run(ctx context.Context) {
-	backoff := time.Duration(0)
-
-	var lastQueueLog time.Time
-
-	for {
-		// Wait for notification, poll timer, or context cancellation.
-		if backoff > 0 {
-			select {
-			case <-ctx.Done():
-				w.drain()
-
-				return
-			case <-time.After(backoff):
-			case <-w.notify:
-			}
-		} else {
-			select {
-			case <-ctx.Done():
-				w.drain()
-
-				return
-			case <-time.After(defaultPollInterval):
-			case <-w.notify:
-			}
-		}
-
-		// Process all available batches.
-		for {
-			if ctx.Err() != nil {
-				w.drain()
-
-				return
-			}
-
-			paths, err := w.queue.FetchBatch(w.batchSize)
-			if err != nil {
-				slog.Error("Failed to fetch batch from queue", "error", err)
-
-				backoff = nextBackoff(backoff)
-
-				break
-			}
-
-			if len(paths) == 0 {
-				// Queue is empty — reset backoff and go back to waiting.
-				backoff = 0
-
-				break
-			}
-
-			// Log queue size periodically.
-			if time.Since(lastQueueLog) > queueLogInterval {
-				if count, err := w.queue.Count(); err == nil && count > 0 {
-					slog.Info("Upload queue status", "pending", count)
-				}
-
-				lastQueueLog = time.Now()
-			}
-
-			// Check which paths still exist locally.
-			var existing []string
-
-			var gcedPaths []string
-
-			for _, p := range paths {
-				if _, err := os.Stat(p); err != nil {
-					slog.Warn("Store path no longer exists (garbage collected?), removing from queue", "path", p)
-					gcedPaths = append(gcedPaths, p)
-				} else {
-					existing = append(existing, p)
-				}
-			}
-
-			// Remove GC'd paths from queue.
-			if len(gcedPaths) > 0 {
-				if err := w.queue.Remove(gcedPaths); err != nil {
-					slog.Error("Failed to remove GC'd paths from queue", "error", err)
-				}
-			}
-
-			if len(existing) == 0 {
-				// All paths in this batch were GC'd; fetch next batch.
-				continue
-			}
-
-			slog.Info("Uploading batch", "count", len(existing))
-
-			uploaded, err := w.push(ctx, existing)
-			if err != nil {
-				slog.Error("Upload failed", "error", err, "count", len(existing))
-
-				backoff = nextBackoff(backoff)
-
-				break
-			}
-
-			// Remove all closure paths from queue, not just the batch.
-			// This prunes dependency paths that were uploaded as part of
-			// a parent's closure, avoiding redundant uploads later.
-			toRemove := existing
-			if len(uploaded) > len(existing) {
-				toRemove = uploaded
-				slog.Debug("Pruning dependency paths from queue",
-					"batch", len(existing), "closure", len(uploaded))
-			}
-
-			if err := w.queue.Remove(toRemove); err != nil {
-				slog.Error("Failed to remove uploaded paths from queue", "error", err)
-			}
-
-			backoff = 0
-		}
-	}
-}
-
 // QueueEmpty reports whether the queue has no pending paths.
 func (w *Worker) QueueEmpty() bool {
 	count, err := w.queue.Count()
@@ -174,50 +59,202 @@ func (w *Worker) QueueEmpty() bool {
 	return count == 0
 }
 
-// drain processes remaining queue entries with a background context.
-func (w *Worker) drain() {
+// Run processes the queue until ctx is cancelled, then makes one final pass
+// over everything still queued (see drain).
+func (w *Worker) Run(ctx context.Context) {
+	backoff := time.Duration(0)
+
+	var lastQueueLog time.Time
+
 	for {
-		paths, err := w.queue.FetchBatch(w.batchSize)
-		if err != nil || len(paths) == 0 {
-			return
+		wait := defaultPollInterval
+		if backoff > 0 {
+			wait = backoff
 		}
 
-		// Check which paths still exist.
-		var existing []string
+		select {
+		case <-ctx.Done():
+			w.drain()
 
-		var gcedPaths []string
+			return
+		case <-time.After(wait):
+		case <-w.notify:
+		}
 
-		for _, p := range paths {
-			if _, err := os.Stat(p); err != nil {
-				gcedPaths = append(gcedPaths, p)
-			} else {
-				existing = append(existing, p)
+		for {
+			if ctx.Err() != nil {
+				w.drain()
+
+				return
+			}
+
+			if time.Since(lastQueueLog) > queueLogInterval {
+				if count, err := w.queue.Count(); err == nil && count > 0 {
+					slog.Info("Upload queue status", "pending", count)
+				}
+
+				lastQueueLog = time.Now()
+			}
+
+			batch, progress := w.step(ctx)
+			if !progress {
+				backoff = nextBackoff(backoff)
+
+				break
+			}
+
+			backoff = 0
+
+			if len(batch) == 0 {
+				break
 			}
 		}
+	}
+}
 
-		if len(gcedPaths) > 0 {
-			_ = w.queue.Remove(gcedPaths)
+// drain is the last pass before exit. Under systemd whatever is left is picked
+// up on the next start, but on an ephemeral CI runner the queue dies with the
+// job, so it keeps going past failures. It gives up once a few batches in a
+// row make no progress, since that points at the server rather than at
+// individual paths; retried paths sort behind untried ones, so little is lost.
+//
+// No timeout: the supervisor (systemd / CI post step) enforces the shutdown
+// budget and SIGKILLs on expiry.
+func (w *Worker) drain() {
+	stalled := 0
+
+	for stalled < isolationProbes {
+		batch, progress := w.step(context.Background())
+		if len(batch) == 0 {
+			break
 		}
 
-		if len(existing) == 0 {
+		if progress {
+			stalled = 0
+		} else {
+			stalled++
+		}
+	}
+
+	if count, err := w.queue.Count(); err == nil && count > 0 {
+		slog.Error("Drain finished with paths left in queue", "remaining", count)
+	}
+}
+
+// step fetches and uploads one batch. It returns the fetched batch (empty when
+// the queue is exhausted or unreadable) and whether anything in it could be
+// settled.
+func (w *Worker) step(ctx context.Context) ([]string, bool) {
+	paths, err := w.queue.FetchBatch(w.batchSize)
+	if err != nil {
+		slog.Error("Failed to fetch batch from queue", "error", err)
+
+		return nil, false
+	}
+
+	if len(paths) == 0 {
+		return nil, true
+	}
+
+	var existing, gced []string
+
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			slog.Warn("Store path no longer exists (garbage collected?), removing from queue", "path", p)
+
+			gced = append(gced, p)
+		} else {
+			existing = append(existing, p)
+		}
+	}
+
+	w.remove(gced)
+
+	if len(existing) == 0 {
+		return paths, true
+	}
+
+	return paths, w.upload(ctx, existing)
+}
+
+// upload pushes a batch; uploaded paths (and their closure) are removed from
+// the queue, failed ones moved to its back. If the batch fails as a whole it is
+// retried path by path so that a single bad path only costs itself. After
+// isolationProbes failures without any success the server is assumed to be the
+// problem and the rest is left in place for the next round.
+func (w *Worker) upload(ctx context.Context, batch []string) bool {
+	slog.Info("Uploading batch", "count", len(batch))
+
+	uploaded, err := w.push(ctx, batch)
+	if err == nil {
+		w.settle(batch, uploaded)
+
+		return true
+	}
+
+	slog.Error("Upload failed", "error", err, "count", len(batch))
+
+	if len(batch) == 1 {
+		w.retry(batch)
+
+		return false
+	}
+
+	done := make(map[string]struct{})
+	failures := 0
+
+	for i, p := range batch {
+		if _, ok := done[p]; ok {
 			continue
 		}
 
-		// No timeout: the supervisor (systemd / CI post step) enforces the
-		// shutdown budget and SIGKILLs on expiry.
-		uploaded, err := w.push(context.Background(), existing)
+		if len(done) == 0 && failures >= isolationProbes {
+			slog.Error("Server seems unavailable, giving up on batch", "untried", len(batch)-i)
+
+			return false
+		}
+
+		uploaded, err := w.push(ctx, []string{p})
 		if err != nil {
-			slog.Error("Drain upload failed, paths remain in queue for next start", "error", err, "count", len(existing))
+			slog.Error("Upload failed, will retry later", "error", err, "path", p)
+			w.retry([]string{p})
 
-			return
+			failures++
+
+			continue
 		}
 
-		toRemove := existing
-		if len(uploaded) > len(existing) {
-			toRemove = uploaded
+		for _, r := range w.settle([]string{p}, uploaded) {
+			done[r] = struct{}{}
 		}
+	}
 
-		_ = w.queue.Remove(toRemove)
+	return len(done) > 0
+}
+
+// settle removes an uploaded batch and its closure from the queue and returns
+// what was removed. Removing the whole closure prunes dependencies that were
+// queued separately but went up as part of a parent.
+func (w *Worker) settle(batch, uploaded []string) []string {
+	toRemove := batch
+	if len(uploaded) > len(batch) {
+		toRemove = uploaded
+	}
+
+	w.remove(toRemove)
+
+	return toRemove
+}
+
+func (w *Worker) remove(paths []string) {
+	if err := w.queue.Remove(paths); err != nil {
+		slog.Error("Failed to remove paths from queue", "error", err, "count", len(paths))
+	}
+}
+
+func (w *Worker) retry(paths []string) {
+	if err := w.queue.Retry(paths); err != nil {
+		slog.Error("Failed to requeue paths", "error", err, "count", len(paths))
 	}
 }
 

--- a/hook/worker_test.go
+++ b/hook/worker_test.go
@@ -2,9 +2,12 @@ package hook_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -51,16 +54,15 @@ func recordingPush() (hook.PushFunc, func() [][]string) {
 	return push, batches
 }
 
-// runWorkerUntilDrained runs a worker for the queue until it is empty (or the
-// test times out), then shuts the worker down.
-func runWorkerUntilDrained(t *testing.T, q *hook.Queue, push hook.PushFunc, batchSize int) {
+// startWorker runs a worker in the background and returns a stop function
+// that cancels it and waits for the shutdown drain to finish.
+func startWorker(t *testing.T, q *hook.Queue, push hook.PushFunc, batchSize int) func() {
 	t.Helper()
 
 	notify := make(chan struct{}, 1)
 	w := hook.NewWorker(q, push, batchSize, notify)
 
 	ctx, cancel := context.WithCancel(context.Background())
-
 	done := make(chan struct{})
 
 	go func() {
@@ -71,25 +73,207 @@ func runWorkerUntilDrained(t *testing.T, q *hook.Queue, push hook.PushFunc, batc
 
 	notify <- struct{}{}
 
+	return func() {
+		t.Helper()
+		cancel()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for worker to stop")
+		}
+	}
+}
+
+// waitForCount blocks until the queue holds exactly n paths.
+func waitForCount(t *testing.T, q *hook.Queue, n int) {
+	t.Helper()
+
 	deadline := time.After(5 * time.Second)
 
 	for {
+		if count, _ := q.Count(); count == n {
+			return
+		}
+
 		select {
 		case <-deadline:
-			t.Fatal("timeout waiting for queue drain")
-		default:
+			count, _ := q.Count()
+			t.Fatalf("timeout waiting for queue count %d, have %d", n, count)
+		case <-time.After(20 * time.Millisecond):
 		}
+	}
+}
 
-		count, _ := q.Count()
-		if count == 0 {
-			break
-		}
+// runWorkerUntilDrained runs a worker until the queue is empty, then stops it.
+func runWorkerUntilDrained(t *testing.T, q *hook.Queue, push hook.PushFunc, batchSize int) {
+	t.Helper()
 
-		time.Sleep(50 * time.Millisecond)
+	stop := startWorker(t, q, push, batchSize)
+	waitForCount(t, q, 0)
+	stop()
+}
+
+// drainWorker runs only the shutdown drain by starting a worker with an
+// already-cancelled context.
+func drainWorker(t *testing.T, q *hook.Queue, push hook.PushFunc, batchSize int) {
+	t.Helper()
+
+	w := hook.NewWorker(q, push, batchSize, make(chan struct{}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		w.Run(ctx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for drain to finish")
+	}
+}
+
+func remaining(t *testing.T, q *hook.Queue) []string {
+	t.Helper()
+
+	paths, err := q.FetchBatch(1000)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	cancel()
-	<-done
+	return paths
+}
+
+func enqueueFiles(t *testing.T, q *hook.Queue, names ...string) []string {
+	t.Helper()
+
+	dir := t.TempDir()
+	paths := make([]string, len(names))
+
+	for i, n := range names {
+		paths[i] = writeTestFile(t, dir, n)
+	}
+
+	if err := q.Enqueue(paths); err != nil {
+		t.Fatal(err)
+	}
+
+	return paths
+}
+
+var errUpload = errors.New("upload failed")
+
+// poisonPush fails any push containing poison and uploads everything else.
+func poisonPush(poison string, calls *atomic.Int32) hook.PushFunc {
+	return func(_ context.Context, paths []string) ([]string, error) {
+		calls.Add(1)
+
+		if slices.Contains(paths, poison) {
+			return nil, errUpload
+		}
+
+		return paths, nil
+	}
+}
+
+// A single unuploadable path in a batch must cost only itself on the final
+// drain; on an ephemeral CI runner the rest of the queue is otherwise lost.
+func TestDrainIsolatesPoisonPath(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+	paths := enqueueFiles(t, q, "aaa", "bbb", "ccc", "ddd")
+	poison := paths[1]
+
+	var calls atomic.Int32
+
+	drainWorker(t, q, poisonPush(poison, &calls), 10)
+
+	if left := remaining(t, q); len(left) != 1 || left[0] != poison {
+		t.Errorf("expected only %s left, got %v", poison, left)
+	}
+}
+
+// During normal operation a permanently failing path at the head of the queue
+// must not block paths behind it until the next restart.
+func TestRunNotBlockedByPoisonHead(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+	paths := enqueueFiles(t, q, "aaa", "bbb", "ccc")
+	poison := paths[0]
+
+	var calls atomic.Int32
+
+	stop := startWorker(t, q, poisonPush(poison, &calls), 1)
+	waitForCount(t, q, 1)
+	stop()
+
+	if left := remaining(t, q); len(left) != 1 || left[0] != poison {
+		t.Errorf("expected only %s left, got %v", poison, left)
+	}
+}
+
+// When nothing at all goes through, drain must terminate on its own, keep
+// every path for a later start and not retry each path individually forever.
+func TestDrainGivesUpWhenServerDown(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+	paths := enqueueFiles(t, q, "a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+
+	var calls atomic.Int32
+
+	push := func(_ context.Context, _ []string) ([]string, error) {
+		calls.Add(1)
+
+		return nil, errUpload
+	}
+
+	drainWorker(t, q, push, 2)
+
+	if left := remaining(t, q); len(left) != len(paths) {
+		t.Errorf("expected all %d paths kept, got %d", len(paths), len(left))
+	}
+
+	// 3 stalled batches × (1 batch push + 2 single-path retries), then stop.
+	if n := calls.Load(); n != 9 {
+		t.Errorf("expected drain to back off from a dead server, got %d push calls", n)
+	}
+}
+
+// A path that failed on its own can still go up later as part of a parent's
+// closure and must be removed from the queue then.
+func TestFailedPathPrunedByLaterClosure(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+	paths := enqueueFiles(t, q, "dep", "top", "last")
+	dep, top := paths[0], paths[1]
+
+	push := func(_ context.Context, batch []string) ([]string, error) {
+		if slices.Contains(batch, top) {
+			return []string{dep, top}, nil
+		}
+
+		if slices.Contains(batch, dep) {
+			return nil, errUpload
+		}
+
+		return batch, nil
+	}
+
+	drainWorker(t, q, push, 1)
+
+	if left := remaining(t, q); len(left) != 0 {
+		t.Errorf("expected empty queue, got %v", left)
+	}
 }
 
 func TestWorkerUploadsAndRemoves(t *testing.T) {

--- a/server/request_test.go
+++ b/server/request_test.go
@@ -54,7 +54,15 @@ func createTestService(tb testing.TB) *server.Service {
 	bucketName := "bucket" + strconv.Itoa(int(testBucketCount.Add(1)))
 	minioClient := testRustfsServer.Client(tb)
 
-	err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
+	// rustfs throttles concurrent CreateBucket calls; parallel tests hit that.
+	for {
+		err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
+		if err == nil || !strings.Contains(err.Error(), "concurrency limit") {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
 	ok(tb, err)
 
 	return &server.Service{


### PR DESCRIPTION
The worker retried the oldest batch forever on push errors, so one path
the server rejects blocked everything behind it, and the shutdown drain
gave up on the first error. On ephemeral CI runners, where the queue
dies with the job, that silently dropped all later paths.

On batch failure, retry paths individually and move failures to the
back of the queue (ordered by rowid now, created_at is too coarse).
Isolation and drain both stop after a few attempts without any success
so a server outage does not multiply requests.
