### PR TITLE
tests: start per-test timeout after t.Parallel()

### DIFF
--- a/server/multipart_cleanup_test.go
+++ b/server/multipart_cleanup_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestMultipartCleanup(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
-
 	t.Parallel()
 
 	service := createTestService(t)
 	defer service.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
 
 	// Create a pending closure with multipart upload
 	closureHash := "dadb44fdadb44fdadb44fdadb44f0000"

--- a/server/uploads_test.go
+++ b/server/uploads_test.go
@@ -242,13 +242,13 @@ func handlePresignedUpload(ctx context.Context, t *testing.T, presignedURL strin
 }
 
 func TestService_createPendingClosureHandler(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
 	t.Parallel()
 
 	service := createTestService(t)
 	defer service.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
 
 	invalidBody, err := json.Marshal(map[string]any{})
 	ok(t, err)
@@ -368,13 +368,13 @@ func TestService_createPendingClosureHandler(t *testing.T) {
 }
 
 func TestService_verifyS3Integrity(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-
 	t.Parallel()
 
 	service := createTestService(t)
 	defer service.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
 
 	// Step 1: Upload a closure
 	closureKey := "dadb44fdadb44fdadb44fdadb44f0000"


### PR DESCRIPTION
t.Parallel() blocks until all sequential tests have finished, and
createTestService spins up a database and bucket. Starting the 10s
context before both meant that on a slow builder most of the budget was
gone before the first request, failing TestService_createPendingClosureHandler
and TestService_verifyS3Integrity on aarch64-darwin with
"context deadline exceeded".
