### PR TITLE
tests: serialize bucket creation instead of retrying

### DIFF
--- a/server/request_test.go
+++ b/server/request_test.go
@@ -54,15 +54,9 @@ func createTestService(tb testing.TB) *server.Service {
 	bucketName := "bucket" + strconv.Itoa(int(testBucketCount.Add(1)))
 	minioClient := testRustfsServer.Client(tb)
 
-	// rustfs throttles concurrent CreateBucket calls; parallel tests hit that.
-	for {
-		err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
-		if err == nil || !strings.Contains(err.Error(), "concurrency limit") {
-			break
-		}
-
-		time.Sleep(100 * time.Millisecond)
-	}
+	testBucketMu.Lock()
+	err = minioClient.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{})
+	testBucketMu.Unlock()
 	ok(tb, err)
 
 	return &server.Service{

--- a/server/rustfs_test.go
+++ b/server/rustfs_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -23,6 +24,9 @@ import (
 var (
 	testRustfsServer *rustfsServer //nolint:gochecknoglobals
 	testBucketCount  atomic.Int32  //nolint:gochecknoglobals
+	// rustfs rejects concurrent CreateBucket calls with 503 SlowDown, which
+	// minio-go retries with backoff long enough to blow the test deadline.
+	testBucketMu sync.Mutex //nolint:gochecknoglobals
 )
 
 type rustfsServer struct {


### PR DESCRIPTION
rustfs rejects concurrent CreateBucket with 503 SlowDown. minio-go 7.3
retries 503 internally with exponential backoff instead of returning it,
so with many parallel tests they all back off in lockstep until the 10s
test deadline expires and the string-matching retry loop never sees the
error. A mutex around MakeBucket avoids hitting the limit at all.
