### PR TITLE
hook: add an optional --drain-timeout to bound the shutdown drain

### DIFF
--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -63,6 +63,8 @@ func printServeHelp() {
 	fmt.Fprintln(os.Stderr, "        Paths per upload batch (default: 50)")
 	fmt.Fprintln(os.Stderr, "  --idle-exit-timeout string")
 	fmt.Fprintln(os.Stderr, `        Exit after no activity; "0" to disable (default: "60s")`)
+	fmt.Fprintln(os.Stderr, "  --drain-timeout duration")
+	fmt.Fprintln(os.Stderr, "        Give up draining the queue on shutdown after this long (default: 0, unbounded)")
 	fmt.Fprintln(os.Stderr, "  --max-concurrent-uploads int")
 	fmt.Fprintln(os.Stderr, "        Concurrent upload limit (default: 30)")
 	fmt.Fprintln(os.Stderr, "  --verify-s3-integrity")
@@ -141,6 +143,7 @@ func runServe() error {
 	dbPath := fs.String("db-path", "/var/lib/niks3-hook/upload-queue.db", "SQLite database path")
 	batchSize := fs.Int("batch-size", 50, "Paths per upload batch")
 	idleExitTimeout := fs.String("idle-exit-timeout", "60s", "Exit after no activity; \"0\" to disable")
+	drainTimeout := fs.Duration("drain-timeout", 0, "Give up draining on shutdown after this long; 0 = unbounded")
 	maxConcurrent := fs.Int("max-concurrent-uploads", 30, "Concurrent upload limit")
 	verifyS3 := fs.Bool("verify-s3-integrity", false, "Verify S3 integrity")
 	tf := cmdutil.AddTLSFlags(fs)
@@ -232,10 +235,12 @@ func runServe() error {
 		"db-path", *dbPath,
 		"batch-size", *batchSize,
 		"idle-exit-timeout", idleTimeout,
+		"drain-timeout", *drainTimeout,
 	)
 
 	// Start the upload worker.
 	worker := hook.NewWorker(queue, c.PushPaths, *batchSize, workerNotify)
+	worker.DrainTimeout = *drainTimeout
 	workerDone := make(chan struct{})
 
 	workerCtx, workerCancel := context.WithCancel(ctx)

--- a/hook/worker.go
+++ b/hook/worker.go
@@ -32,6 +32,8 @@ type Worker struct {
 	push      PushFunc
 	batchSize int
 	notify    <-chan struct{} // Woken on enqueue.
+
+	DrainTimeout time.Duration // 0 = unbounded
 }
 
 // NewWorker creates a Worker that reads from queue and calls push for each batch.
@@ -118,13 +120,22 @@ func (w *Worker) Run(ctx context.Context) {
 // row make no progress, since that points at the server rather than at
 // individual paths; retried paths sort behind untried ones, so little is lost.
 //
-// No timeout: the supervisor (systemd / CI post step) enforces the shutdown
-// budget and SIGKILLs on expiry.
+// Unbounded by default since systemd enforces TimeoutStopSec; DrainTimeout is
+// for unsupervised runs. Either way an external SIGKILL remains the backstop.
 func (w *Worker) drain() {
+	ctx := context.Background()
+
+	if w.DrainTimeout > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, w.DrainTimeout)
+		defer cancel()
+	}
+
 	stalled := 0
 
-	for stalled < isolationProbes {
-		batch, progress := w.step(context.Background())
+	for stalled < isolationProbes && ctx.Err() == nil {
+		batch, progress := w.step(ctx)
 		if len(batch) == 0 {
 			break
 		}
@@ -193,6 +204,11 @@ func (w *Worker) upload(ctx context.Context, batch []string) bool {
 	}
 
 	slog.Error("Upload failed", "error", err, "count", len(batch))
+
+	// Cancelled/timed out: not the paths' fault, leave them where they are.
+	if ctx.Err() != nil {
+		return false
+	}
 
 	if len(batch) == 1 {
 		w.retry(batch)

--- a/hook/worker_test.go
+++ b/hook/worker_test.go
@@ -119,7 +119,21 @@ func runWorkerUntilDrained(t *testing.T, q *hook.Queue, push hook.PushFunc, batc
 func drainWorker(t *testing.T, q *hook.Queue, push hook.PushFunc, batchSize int) {
 	t.Helper()
 
+	drainWorkerTimeout(t, q, push, batchSize, 0)
+}
+
+// drainWorkerTimeout is drainWorker with a DrainTimeout budget.
+func drainWorkerTimeout(
+	t *testing.T,
+	q *hook.Queue,
+	push hook.PushFunc,
+	batchSize int,
+	drainTimeout time.Duration,
+) {
+	t.Helper()
+
 	w := hook.NewWorker(q, push, batchSize, make(chan struct{}))
+	w.DrainTimeout = drainTimeout
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -364,5 +378,39 @@ func TestWorkerPrunesClosureDeps(t *testing.T) {
 
 	if count != 0 {
 		t.Errorf("expected empty queue, got %d remaining", count)
+	}
+}
+
+// A hung server must not keep an unsupervised drain alive forever, and the
+// interrupted paths must stay queued in their original order.
+func TestDrainTimeout(t *testing.T) {
+	t.Parallel()
+
+	q := newTestQueue(t)
+	paths := enqueueFiles(t, q, "a", "b", "c", "d")
+
+	var calls atomic.Int32
+
+	push := func(ctx context.Context, _ []string) ([]string, error) {
+		calls.Add(1)
+		<-ctx.Done()
+
+		return nil, ctx.Err()
+	}
+
+	start := time.Now()
+
+	drainWorkerTimeout(t, q, push, 2, 200*time.Millisecond)
+
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("drain ignored its timeout, took %s", elapsed)
+	}
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected no isolation probes after timeout, got %d pushes", n)
+	}
+
+	if left := remaining(t, q); !slices.Equal(left, paths) {
+		t.Errorf("expected queue untouched %v, got %v", paths, left)
 	}
 }


### PR DESCRIPTION
`drain()` is unbounded on purpose, deferring the shutdown budget to the supervisor.
That holds under systemd, where `TimeoutStopSec` exists, but without a unit there is nothing to defer to: _niks3-action_ and a Buildkite step have both since grown the same SIGTERM/poll/SIGKILL loop around the process, both budgeting 600s.

Let the daemon bound its own drain instead. Defaults to "0" (unbounded), so supervised deployments are unchanged and two timeouts cannot race.

It does not replace the external SIGKILL: a cooperative deadline only fires while the daemon is still checking it, so a deadlock or a stuck syscall still needs the backstop.
