### PR TITLE
Kubernetes: Helm chart, workload identity, OIDC scopes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,17 @@ jobs:
         run: nix shell --inputs-from . nixpkgs#goreleaser --command goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  helm-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: azure/setup-helm@v4
+      - name: Publish chart
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          helm package deploy/helm/niks3 --version "$version" --app-version "$GITHUB_REF_NAME"
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+          helm push "niks3-$version.tgz" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/charts"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ For detailed pricing comparison and alternative providers, see the [S3 Provider 
 
 For complete setup instructions, see the [Setup Guide](https://github.com/Mic92/niks3/wiki/Setup-Guide) in the wiki.
 
+## Kubernetes
+
+Chart: `oci://ghcr.io/mic92/charts/niks3` (source in [`deploy/helm/niks3`](deploy/helm/niks3)), image: `ghcr.io/mic92/niks3`.
+See the [Kubernetes](https://github.com/Mic92/niks3/wiki/Kubernetes) wiki page
+for Postgres/S3 wiring and letting pods push via their service account token.
+
 ## OIDC Authentication (CI/CD)
 
 niks3 supports OIDC authentication for CI/CD systems. See the wiki for details:

--- a/deploy/helm/niks3/Chart.yaml
+++ b/deploy/helm/niks3/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: niks3
+description: S3-backed Nix binary cache with garbage collection
+type: application
+version: 0.1.0
+# version/appVersion are set from the git tag on release.
+appVersion: "v1.9.0"
+icon: https://raw.githubusercontent.com/Mic92/niks3/main/server/niks3.svg
+home: https://github.com/Mic92/niks3
+sources:
+  - https://github.com/Mic92/niks3

--- a/deploy/helm/niks3/templates/NOTES.txt
+++ b/deploy/helm/niks3/templates/NOTES.txt
@@ -1,0 +1,17 @@
+niks3 is reachable in-cluster at http://{{ include "niks3.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+{{- range .Values.ingress.hosts }}{{ if $.Values.ingress.enabled }}
+and at http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ end }}{{ end }}
+
+Push from a machine holding the API token:
+  NIKS3_SERVER_URL=<url> NIKS3_AUTH_TOKEN_FILE=<token file> niks3 push ./result
+{{- if .Values.auth.workloadIdentity.enabled }}
+
+Pods running as {{ join ", " .Values.auth.workloadIdentity.allowedServiceAccounts }} can push with a
+projected service account token (audience "{{ .Values.auth.workloadIdentity.audience }}"), see
+https://github.com/Mic92/niks3/wiki/Kubernetes
+{{- end }}
+{{- if .Values.gc.enabled }}
+
+Garbage collection runs on schedule "{{ .Values.gc.schedule }}". Trigger manually:
+  kubectl -n {{ .Release.Namespace }} create job --from=cronjob/{{ include "niks3.fullname" . }}-gc gc-manual
+{{- end }}

--- a/deploy/helm/niks3/templates/_helpers.tpl
+++ b/deploy/helm/niks3/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{- define "niks3.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "niks3.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "niks3.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{ include "niks3.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "niks3.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "niks3.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "niks3.serverSelectorLabels" -}}
+{{ include "niks3.selectorLabels" . }}
+app.kubernetes.io/component: server
+{{- end }}
+
+{{- define "niks3.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "niks3.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "niks3.image" -}}
+{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+
+{{- define "niks3.dbSecretName" -}}
+{{- if not (or .Values.database.existingSecret .Values.database.url) }}
+{{- fail "set database.existingSecret or database.url" }}
+{{- end }}
+{{- default (printf "%s-db" (include "niks3.fullname" .)) .Values.database.existingSecret }}
+{{- end }}
+
+{{- define "niks3.tokenSecretName" -}}
+{{- if not (or .Values.auth.existingSecret .Values.auth.token) }}
+{{- fail "set auth.existingSecret or auth.token" }}
+{{- end }}
+{{- default (printf "%s-token" (include "niks3.fullname" .)) .Values.auth.existingSecret }}
+{{- end }}
+
+{{/* OIDC providers map incl. the synthesized Kubernetes one; empty when unused. */}}
+{{- define "niks3.oidcProviders" -}}
+{{- $providers := deepCopy (.Values.auth.oidcProviders | default dict) }}
+{{- with .Values.auth.workloadIdentity }}
+{{- if .enabled }}
+{{- $subjects := list }}
+{{- range (required "auth.workloadIdentity.allowedServiceAccounts must not be empty" .allowedServiceAccounts) }}
+{{- $subjects = append $subjects (printf "system:serviceaccount:%s" .) }}
+{{- end }}
+{{- $_ := set $providers "kubernetes" (dict
+  "issuer" .issuer
+  "audience" .audience
+  "bound_subject" $subjects
+  "scopes" .scopes
+  "ca_file" "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  "bearer_token_file" "/var/run/secrets/kubernetes.io/serviceaccount/token") }}
+{{- end }}
+{{- end }}
+{{- if $providers }}{{ toJson (dict "providers" $providers) }}{{- end }}
+{{- end }}
+
+{{- define "niks3.s3SecretName" -}}
+{{- if not (or .Values.s3.existingSecret .Values.s3.accessKey) }}
+{{- fail "set s3.useIAM, s3.existingSecret or s3.accessKey/secretKey" }}
+{{- end }}
+{{- default (printf "%s-s3" (include "niks3.fullname" .)) .Values.s3.existingSecret }}
+{{- end }}

--- a/deploy/helm/niks3/templates/deployment.yaml
+++ b/deploy/helm/niks3/templates/deployment.yaml
@@ -1,0 +1,173 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "niks3.fullname" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "niks3.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "niks3.serverSelectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "niks3.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.auth.workloadIdentity.enabled }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: niks3
+          image: {{ include "niks3.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- range .Values.signing.keys }}
+            - --sign-key-path=/secrets/signing/{{ . }}
+            {{- end }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: NIKS3_HTTP_ADDR
+              value: ":5751"
+            - name: NIKS3_DB_FILE
+              value: /secrets/db/{{ .Values.database.secretKey }}
+            - name: NIKS3_API_TOKEN_PATH
+              value: /secrets/token/token
+            - name: NIKS3_S3_ENDPOINT
+              value: {{ required "s3.endpoint is required" .Values.s3.endpoint | quote }}
+            - name: NIKS3_S3_BUCKET
+              value: {{ required "s3.bucket is required" .Values.s3.bucket | quote }}
+            - name: NIKS3_S3_USE_SSL
+              value: {{ .Values.s3.useSSL | quote }}
+            - name: NIKS3_S3_BUCKET_LOOKUP
+              value: {{ .Values.s3.bucketLookup | quote }}
+            {{- with .Values.s3.region }}
+            - name: NIKS3_S3_REGION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.s3.useIAM }}
+            - name: NIKS3_S3_USE_IAM
+              value: "true"
+            {{- else }}
+            - name: NIKS3_S3_ACCESS_KEY_PATH
+              value: /secrets/s3/access-key
+            - name: NIKS3_S3_SECRET_KEY_PATH
+              value: /secrets/s3/secret-key
+            {{- end }}
+            {{- with .Values.cacheURL }}
+            - name: NIKS3_CACHE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.readProxy.enabled }}
+            - name: NIKS3_ENABLE_READ_PROXY
+              value: "true"
+            {{- if not (kindIs "invalid" .Values.readProxy.redirectTTL) }}
+            - name: NIKS3_READ_REDIRECT_TTL
+              value: {{ .Values.readProxy.redirectTTL | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.maxNarSize) }}
+            - name: NIKS3_MAX_NAR_SIZE
+              value: {{ .Values.maxNarSize | quote }}
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.cachePriority) }}
+            - name: NIKS3_CACHE_PRIORITY
+              value: {{ .Values.cachePriority | quote }}
+            {{- end }}
+            {{- if include "niks3.oidcProviders" . }}
+            - name: NIKS3_OIDC_CONFIG
+              value: /etc/niks3/oidc.json
+            {{- end }}
+            {{- if .Values.debug }}
+            - name: NIKS3_DEBUG
+              value: "true"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 5751
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            timeoutSeconds: 3
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- with .Values.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: db
+              mountPath: /secrets/db
+              readOnly: true
+            - name: token
+              mountPath: /secrets/token
+              readOnly: true
+            {{- if not .Values.s3.useIAM }}
+            - name: s3
+              mountPath: /secrets/s3
+              readOnly: true
+            {{- end }}
+            {{- if .Values.signing.existingSecret }}
+            - name: signing
+              mountPath: /secrets/signing
+              readOnly: true
+            {{- end }}
+            {{- if include "niks3.oidcProviders" . }}
+            - name: oidc
+              mountPath: /etc/niks3
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: db
+          secret:
+            secretName: {{ include "niks3.dbSecretName" . }}
+        - name: token
+          secret:
+            secretName: {{ include "niks3.tokenSecretName" . }}
+        {{- if not .Values.s3.useIAM }}
+        - name: s3
+          secret:
+            secretName: {{ include "niks3.s3SecretName" . }}
+        {{- end }}
+        {{- with .Values.signing.existingSecret }}
+        - name: signing
+          secret:
+            secretName: {{ . }}
+        {{- end }}
+        {{- if include "niks3.oidcProviders" . }}
+        - name: oidc
+          configMap:
+            name: {{ include "niks3.fullname" . }}-oidc
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - {{ toYaml (merge (dict "labelSelector" (dict "matchLabels" (include "niks3.serverSelectorLabels" $ | fromYaml))) .) | nindent 10 | trim }}
+        {{- end }}
+      {{- end }}

--- a/deploy/helm/niks3/templates/gc-cronjob.yaml
+++ b/deploy/helm/niks3/templates/gc-cronjob.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.gc.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "niks3.fullname" . }}-gc
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.gc.schedule | quote }}
+  startingDeadlineSeconds: 3600
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels: {{- include "niks3.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: gc
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "niks3.serviceAccountName" . }}
+          automountServiceAccountToken: false
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext: {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: gc
+              image: {{ include "niks3.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["/bin/niks3"]
+              args:
+                - gc
+                - --server-url=http://{{ include "niks3.fullname" . }}:{{ .Values.service.port }}
+                - --auth-token-path=/secrets/token/token
+                - --older-than={{ .Values.gc.olderThan }}
+                - --failed-uploads-older-than={{ .Values.gc.failedUploadsOlderThan }}
+              securityContext: {{- toYaml .Values.securityContext | nindent 16 }}
+              {{- with .Values.gc.resources }}
+              resources: {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: token
+                  mountPath: /secrets/token
+                  readOnly: true
+          volumes:
+            - name: token
+              secret:
+                secretName: {{ include "niks3.tokenSecretName" . }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations: {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/niks3/templates/ingress.yaml
+++ b/deploy/helm/niks3/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "niks3.fullname" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "niks3.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/niks3/templates/pdb.yaml
+++ b/deploy/helm/niks3/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "niks3.fullname" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels: {{- include "niks3.serverSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/niks3/templates/secrets.yaml
+++ b/deploy/helm/niks3/templates/secrets.yaml
@@ -1,0 +1,40 @@
+{{- if and (not .Values.database.existingSecret) .Values.database.url }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "niks3.dbSecretName" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+stringData:
+  {{ .Values.database.secretKey }}: {{ .Values.database.url | quote }}
+{{- end }}
+{{- if and (not .Values.auth.existingSecret) .Values.auth.token }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "niks3.tokenSecretName" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+stringData:
+  token: {{ .Values.auth.token | quote }}
+{{- end }}
+{{- if and (not .Values.s3.useIAM) (not .Values.s3.existingSecret) .Values.s3.accessKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "niks3.s3SecretName" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+stringData:
+  access-key: {{ .Values.s3.accessKey | quote }}
+  secret-key: {{ .Values.s3.secretKey | quote }}
+{{- end }}
+{{- with include "niks3.oidcProviders" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "niks3.fullname" $ }}-oidc
+  labels: {{- include "niks3.labels" $ | nindent 4 }}
+data:
+  oidc.json: {{ . | quote }}
+{{- end }}

--- a/deploy/helm/niks3/templates/service.yaml
+++ b/deploy/helm/niks3/templates/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "niks3.fullname" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+      protocol: TCP
+      name: http
+  selector: {{- include "niks3.serverSelectorLabels" . | nindent 4 }}
+---
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "niks3.serviceAccountName" . }}
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/niks3/templates/servicemonitor.yaml
+++ b/deploy/helm/niks3/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "niks3.fullname" . }}
+  labels:
+    {{- include "niks3.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "niks3.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/niks3/templates/tests/readyz.yaml
+++ b/deploy/helm/niks3/templates/tests/readyz.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "niks3.fullname" . }}-test
+  labels: {{- include "niks3.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext: {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: readyz
+      image: {{ include "niks3.image" . }}
+      command: ["/bin/wget", "-qO-", "http://{{ include "niks3.fullname" . }}:{{ .Values.service.port }}/readyz"]
+      securityContext: {{- toYaml .Values.securityContext | nindent 8 }}

--- a/deploy/helm/niks3/values.schema.json
+++ b/deploy/helm/niks3/values.schema.json
@@ -1,0 +1,316 @@
+{
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "s3": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "useSSL": {
+          "type": "boolean"
+        },
+        "bucketLookup": {
+          "enum": [
+            "auto",
+            "dns",
+            "path"
+          ]
+        },
+        "useIAM": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "accessKey": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "workloadIdentity": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowedServiceAccounts": {
+              "type": "array"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "read",
+                  "write",
+                  "admin"
+                ]
+              }
+            },
+            "audience": {
+              "type": "string"
+            },
+            "issuer": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "oidcProviders": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "signing": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "keys": {
+          "type": "array"
+        }
+      },
+      "additionalProperties": false
+    },
+    "cacheURL": {
+      "type": "string"
+    },
+    "readProxy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "redirectTTL": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "maxNarSize": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cachePriority": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "debug": {
+      "type": "boolean"
+    },
+    "extraArgs": {
+      "type": "array"
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "nodePort": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array"
+        },
+        "tls": {
+          "type": "array"
+        }
+      },
+      "additionalProperties": false
+    },
+    "gc": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "olderThan": {
+          "type": "string"
+        },
+        "failedUploadsOlderThan": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "global": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "$schema": "https://json-schema.org/draft-07/schema#"
+}

--- a/deploy/helm/niks3/values.yaml
+++ b/deploy/helm/niks3/values.yaml
@@ -1,0 +1,98 @@
+image:
+  repository: ghcr.io/mic92/niks3
+  tag: "" # defaults to appVersion
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+replicaCount: 1
+resources: {}
+database:
+  # Secret with the Postgres connection string (CloudNativePG: `<cluster>-app`, key `uri`).
+  existingSecret: ""
+  secretKey: uri
+  # Or inline. The chart creates the Secret.
+  url: ""
+s3:
+  endpoint: ""
+  bucket: ""
+  region: ""
+  useSSL: true
+  bucketLookup: auto # auto | dns | path
+  # IRSA / Pod Identity instead of keys from `existingSecret` (access-key / secret-key).
+  useIAM: false
+  existingSecret: ""
+  accessKey: ""
+  secretKey: ""
+auth:
+  # Shared API token (>= 36 chars) for uploads and GC; Secret key `token`.
+  existingSecret: ""
+  token: ""
+  # Allow pods to push with their service account token, see wiki/Kubernetes.
+  workloadIdentity:
+    enabled: false
+    allowedServiceAccounts: [] # "<namespace>:<name>", globs allowed
+    scopes: [write] # read | write | admin
+    audience: niks3
+    issuer: https://kubernetes.default.svc.cluster.local
+  # Further OIDC providers in the server's JSON schema, keyed by name.
+  oidcProviders: {}
+signing:
+  existingSecret: ""
+  keys: [] # file names within the Secret
+cacheURL: ""
+readProxy:
+  enabled: false
+  redirectTTL: null # e.g. 15m
+maxNarSize: null # e.g. 4G
+cachePriority: null # e.g. 30
+debug: false
+extraArgs: []
+extraEnv: []
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: [] # labelSelector is filled in
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+service:
+  type: ClusterIP
+  port: 80
+  nodePort: null
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: niks3.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+gc:
+  enabled: true
+  schedule: "0 3 * * *"
+  olderThan: 720h
+  failedUploadsOlderThan: 6h
+  resources: {}
+metrics:
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -83,4 +83,7 @@ packages
     niks3 = selfPackages.niks3;
     rustfs = pkgs.rustfs;
   };
+  nixos-test-k3s = pkgs.callPackage ./nixos-test-k3s.nix {
+    inherit (selfPackages) niks3 niks3-docker;
+  };
 }

--- a/nix/checks/nixos-test-k3s.nix
+++ b/nix/checks/nixos-test-k3s.nix
@@ -1,0 +1,194 @@
+# Helm chart in k3s. Pushes authenticate with a service account token.
+{
+  testers,
+  runCommand,
+  kubernetes-helm,
+  s5cmd,
+  rustfs,
+  k3s,
+  niks3,
+  niks3-docker,
+  system,
+  ...
+}:
+let
+  image = niks3-docker.perArch.${system};
+
+  chart = runCommand "niks3-chart.tgz" { nativeBuildInputs = [ kubernetes-helm ]; } ''
+    cp -r ${../../deploy/helm/niks3} chart
+    chmod -R u+w chart
+    helm package chart
+    mv niks3-*.tgz $out
+  '';
+
+  apiToken = "test-token-that-is-at-least-36-characters-long";
+  hostIP = "192.168.1.1";
+  nodePort = 30051;
+in
+testers.nixosTest {
+  name = "nixos-test-k3s";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation = {
+        memorySize = 3072;
+        cores = 2;
+        diskSize = 8192;
+      };
+      networking.firewall.enable = false;
+      environment.systemPackages = [
+        pkgs.kubectl
+        pkgs.kubernetes-helm
+        niks3
+      ];
+      nix.settings.experimental-features = [ "nix-command" ];
+      environment.sessionVariables.KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
+
+      services.postgresql = {
+        enable = true;
+        enableTCPIP = true;
+        ensureDatabases = [ "niks3" ];
+        ensureUsers = [
+          {
+            name = "niks3";
+            ensureDBOwnership = true;
+          }
+        ];
+        authentication = "host all all 10.42.0.0/16 trust";
+      };
+
+      systemd.services.rustfs = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${rustfs}/bin/rustfs --address 0.0.0.0:9000 --access-key rustfsadmin --secret-key rustfsadmin /var/lib/rustfs";
+          StateDirectory = "rustfs";
+          DynamicUser = true;
+        };
+      };
+      systemd.services.rustfs-setup = {
+        after = [ "rustfs.service" ];
+        requires = [ "rustfs.service" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = {
+          S3_ENDPOINT_URL = "http://localhost:9000";
+          AWS_ACCESS_KEY_ID = "rustfsadmin";
+          AWS_SECRET_ACCESS_KEY = "rustfsadmin";
+        };
+        path = [ s5cmd ];
+        script = ''
+          for i in $(seq 60); do s5cmd ls 2>/dev/null && break; sleep 2; done
+          s5cmd mb s3://niks3 || true
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+      };
+
+      services.k3s = {
+        enable = true;
+        role = "server";
+        package = k3s;
+        disable = [
+          "traefik"
+          "metrics-server"
+          "local-storage"
+        ];
+        images = [
+          k3s.airgap-images
+          image
+        ];
+        autoDeployCharts.niks3 = {
+          package = chart;
+          targetNamespace = "niks3";
+          createNamespace = true;
+          values = {
+            image = {
+              repository = image.imageName;
+              tag = image.imageTag;
+            };
+            database.url = "postgres://niks3@${hostIP}/niks3?sslmode=disable";
+            s3 = {
+              endpoint = "${hostIP}:9000";
+              bucket = "niks3";
+              useSSL = false;
+              accessKey = "rustfsadmin";
+              secretKey = "rustfsadmin";
+            };
+            auth = {
+              token = apiToken;
+              workloadIdentity = {
+                enabled = true;
+                allowedServiceAccounts = [ "ci:builder" ];
+              };
+            };
+            service = {
+              type = "NodePort";
+              inherit nodePort;
+            };
+          };
+        };
+        manifests.ci.content = [
+          {
+            apiVersion = "v1";
+            kind = "Namespace";
+            metadata.name = "ci";
+          }
+          {
+            apiVersion = "v1";
+            kind = "ServiceAccount";
+            metadata = {
+              name = "builder";
+              namespace = "ci";
+            };
+          }
+          {
+            apiVersion = "v1";
+            kind = "ServiceAccount";
+            metadata = {
+              name = "intruder";
+              namespace = "ci";
+            };
+          }
+        ];
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("k3s.service")
+    machine.wait_for_unit("rustfs-setup.service")
+    machine.wait_for_unit("postgresql.service")
+
+    with subtest("chart deploys and becomes ready"):
+      machine.wait_until_succeeds("kubectl -n niks3 rollout status deployment niks3 --timeout=10s", timeout=300)
+      machine.wait_until_succeeds("curl -sf http://localhost:${toString nodePort}/readyz | grep OK", timeout=60)
+
+    # Same JWT a pod gets from a projected serviceAccountToken volume.
+    machine.wait_until_succeeds("kubectl -n ci get sa builder", timeout=60)
+    machine.succeed("kubectl -n ci create token builder --audience niks3 > /tmp/builder.jwt")
+    machine.succeed("kubectl -n ci create token intruder --audience niks3 > /tmp/intruder.jwt")
+    push = "NIKS3_SERVER_URL=http://localhost:${toString nodePort} NIKS3_AUTH_TOKEN_FILE=/tmp/{}.jwt niks3 push {} 2>&1"
+    path = machine.succeed("readlink -f /run/current-system/sw/bin/niks3").strip().removesuffix("/bin/niks3")
+
+    with subtest("allowed service account can push via workload identity"):
+      print(machine.succeed(push.format("builder", path)))
+      hash = path.removeprefix("/nix/store/").split("-")[0]
+      machine.succeed(f"curl -sf -H 'Authorization: Bearer ${apiToken}' -I http://localhost:${toString nodePort}/api/objects/{hash}.narinfo")
+
+    with subtest("write scope does not grant admin"):
+      status = "curl -s -o /dev/null -w '%{{http_code}}' -H \"Authorization: Bearer $(cat /tmp/{}.jwt)\" http://localhost:${toString nodePort}/api/gc/status"
+      assert machine.succeed(status.format("builder")).strip() == "403"
+
+    with subtest("other service accounts are rejected"):
+      out = machine.fail(push.format("intruder", path))
+      assert "401" in out or "nauthorized" in out, out
+
+    with subtest("gc cronjob runs against the service"):
+      machine.succeed("kubectl -n niks3 create job --from=cronjob/niks3-gc gc-manual")
+      machine.wait_until_succeeds("kubectl -n niks3 wait --for=condition=complete job/gc-manual --timeout=10s", timeout=120)
+
+    with subtest("helm test hook passes"):
+      machine.succeed("helm test -n niks3 niks3 --timeout 2m >&2")
+  '';
+}

--- a/nix/formatter/default.nix
+++ b/nix/formatter/default.nix
@@ -10,6 +10,8 @@ let
     programs.deadnix.enable = true;
     programs.gofumpt.enable = true;
     programs.yamlfmt.enable = true;
+    # Helm templates are Go templates, not valid YAML.
+    settings.formatter.yamlfmt.excludes = [ "deploy/helm/*/templates/*" ];
     programs.mdformat.enable = true;
     programs.sqlfluff.enable = true;
     programs.sqlfluff.dialect = "postgres";

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -8,6 +8,11 @@
 
 let
   cfg = config.services.niks3;
+  scopeType = lib.types.enum [
+    "read"
+    "write"
+    "admin"
+  ];
 
   # OIDC provider submodule
   providerModule = lib.types.submodule {
@@ -56,6 +61,40 @@ let
         example = [ "repo:myorg/*:*" ];
       };
 
+      scopes = lib.mkOption {
+        type = lib.types.listOf scopeType;
+        default = [ "write" ];
+        description = "Scopes granted when boundClaims/boundSubject match. Ignored when rules is set.";
+      };
+
+      rules = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              boundClaims = lib.mkOption {
+                type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+                default = { };
+              };
+              boundSubject = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+              };
+              scopes = lib.mkOption {
+                type = lib.types.nonEmptyListOf scopeType;
+              };
+            };
+          }
+        );
+        default = [ ];
+        description = "Grant scopes per matching rule (union). Replaces top-level boundClaims/boundSubject/scopes.";
+        example = lib.literalExpression ''
+          [
+            { boundSubject = [ "repo:myorg/*:ref:refs/heads/main" ]; scopes = [ "write" ]; }
+            { boundSubject = [ "repo:myorg/infra:*" ]; scopes = [ "write" "admin" ]; }
+          ]
+        '';
+      };
+
       caFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -80,12 +119,22 @@ let
             issuer = provider.issuer;
             audience = provider.audience;
           }
-          // lib.optionalAttrs (provider.boundClaims != { }) {
-            bound_claims = provider.boundClaims;
-          }
-          // lib.optionalAttrs (provider.boundSubject != [ ]) {
-            bound_subject = provider.boundSubject;
-          }
+          // (
+            if provider.rules != [ ] then
+              {
+                rules = map (r: {
+                  bound_claims = r.boundClaims;
+                  bound_subject = r.boundSubject;
+                  scopes = r.scopes;
+                }) provider.rules;
+              }
+            else
+              {
+                bound_claims = provider.boundClaims;
+                bound_subject = provider.boundSubject;
+                scopes = provider.scopes;
+              }
+          )
           // lib.optionalAttrs (provider.caFile != null) {
             ca_file = toString provider.caFile;
           }

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -55,6 +55,18 @@ let
         '';
         example = [ "repo:myorg/*:*" ];
       };
+
+      caFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "CA bundle to verify the issuer with, for issuers behind a private CA (e.g. a Kubernetes API server).";
+      };
+
+      bearerTokenFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Bearer token sent when fetching discovery/JWKS, for issuers that require authentication (e.g. a Kubernetes API server).";
+      };
     };
   };
 
@@ -73,6 +85,12 @@ let
           }
           // lib.optionalAttrs (provider.boundSubject != [ ]) {
             bound_subject = provider.boundSubject;
+          }
+          // lib.optionalAttrs (provider.caFile != null) {
+            ca_file = toString provider.caFile;
+          }
+          // lib.optionalAttrs (provider.bearerTokenFile != null) {
+            bearer_token_file = toString provider.bearerTokenFile;
           }
         ) cfg.oidc.providers;
       }

--- a/nix/packages/niks3-docker.nix
+++ b/nix/packages/niks3-docker.nix
@@ -76,6 +76,7 @@ in
 pkgs.stdenvNoCC.mkDerivation {
   name = "${niks3-server.pname}-docker";
   inherit (niks3-server) version;
+  passthru.perArch = platforms;
   phases = [ "installPhase" ];
   src = pkgs.linkFarm "images" (lib.mapAttrsToList (name: path: { inherit name path; }) platforms);
   nativeBuildInputs = [ pkgs.regctl ];

--- a/server/auth.go
+++ b/server/auth.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"crypto/subtle"
+	"errors"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/Mic92/niks3/server/oidc"
+)
+
+var allScopes = []oidc.Scope{oidc.ScopeRead, oidc.ScopeWrite, oidc.ScopeAdmin}
+
+// readGated reports whether the read proxy requires authentication. Reads are
+// public unless the operator configured a read rule somewhere, since Nix
+// substituters present no credentials and contents are signed.
+func (s *Service) readGated() bool {
+	return len(s.MTLSBoundSubjectsRead) > 0 || (s.OIDCValidator != nil && s.OIDCValidator.GrantsScope(oidc.ScopeRead))
+}
+
+// requestScopes authenticates r and returns the granted scopes. ok is false
+// when no valid credentials were presented at all.
+func (s *Service) requestScopes(r *http.Request) (scopes []oidc.Scope, ok bool) {
+	if s.mtlsCheck(r, s.MTLSBoundSubjects) {
+		return allScopes, true
+	}
+
+	if len(s.MTLSBoundSubjectsRead) > 0 && s.mtlsCheck(r, s.MTLSBoundSubjectsRead) {
+		return []oidc.Scope{oidc.ScopeRead}, true
+	}
+
+	token, found := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !found || token == "" {
+		return nil, false
+	}
+
+	if s.APIToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(s.APIToken)) == 1 {
+		return allScopes, true
+	}
+
+	if s.OIDCValidator == nil {
+		s.logAuthFailure(token, nil)
+
+		return nil, false
+	}
+
+	claims, err := s.OIDCValidator.ValidateToken(r.Context(), token)
+	if err != nil {
+		var vErr *oidc.ValidationError
+
+		errors.As(err, &vErr)
+		s.logAuthFailure(token, vErr)
+
+		return nil, false
+	}
+
+	slog.Info("OIDC auth successful", "provider", claims.Provider, "scopes", claims.Scopes)
+	slog.Debug("OIDC auth details", "subject", claims.Subject)
+
+	scopes = claims.Scopes
+	// Anyone who may upload or administer may also read.
+	if !claims.Has(oidc.ScopeRead) {
+		scopes = append(slices.Clone(scopes), oidc.ScopeRead)
+	}
+
+	return scopes, true
+}
+
+// RequireScope wraps next so it only runs for principals holding scope.
+func (s *Service) RequireScope(scope oidc.Scope, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if scope == oidc.ScopeRead && !s.readGated() {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		scopes, ok := s.requestScopes(r)
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+
+			return
+		}
+
+		if !slices.Contains(scopes, scope) {
+			http.Error(w, "Forbidden: token lacks scope "+string(scope), http.StatusForbidden)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -24,7 +24,7 @@ func TestService_AuthMiddleware(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		header: map[string]string{
 			"Authorization": "Bearer " + service.APIToken,
 		},
@@ -41,7 +41,7 @@ func TestService_AuthMiddleware(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 		header: map[string]string{
 			"Authorization": "Bearer wrongtoken",
@@ -63,7 +63,7 @@ func TestService_AuthMiddleware_MTLSProxyHeader(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 		},
@@ -82,7 +82,7 @@ func TestService_AuthMiddleware_MTLSProxyHeader(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 		header: map[string]string{
 			"X-SSL-Client-Verify": "NONE",
@@ -93,7 +93,7 @@ func TestService_AuthMiddleware_MTLSProxyHeader(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 	})
 
@@ -102,7 +102,7 @@ func TestService_AuthMiddleware_MTLSProxyHeader(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
@@ -134,7 +134,7 @@ func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 			"X-SSL-Client-Dn":     "CN=ci-runner,O=Acme",
@@ -145,7 +145,7 @@ func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 			"X-SSL-Client-Dn":     "CN=admin",
@@ -156,7 +156,7 @@ func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
@@ -168,7 +168,7 @@ func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.AuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
@@ -179,7 +179,7 @@ func TestService_AuthMiddleware_MTLSBoundSubjects(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.AuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 			"X-SSL-Client-Dn":     "CN=untrusted",
@@ -210,7 +210,7 @@ func TestService_ReadAuthMiddleware(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.ReadAuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler),
 	})
 
 	// Read bound subjects set → unauthenticated read rejected.
@@ -218,7 +218,7 @@ func TestService_ReadAuthMiddleware(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:        "GET",
 		path:          "/health",
-		handler:       service.ReadAuthMiddleware(service.HealthCheckHandler),
+		handler:       service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler),
 		checkResponse: &checkUnauthorized,
 	})
 
@@ -226,20 +226,19 @@ func TestService_ReadAuthMiddleware(t *testing.T) {
 	testRequest(t, &TestRequest{
 		method:  "GET",
 		path:    "/health",
-		handler: service.ReadAuthMiddleware(service.HealthCheckHandler),
+		handler: service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 			"X-SSL-Client-Dn":     "CN=reader-1",
 		},
 	})
 
-	// Subject allowed for write but not read.
+	// Write subjects may read too.
 	service.MTLSBoundSubjects = []string{"CN=writer"}
 	testRequest(t, &TestRequest{
-		method:        "GET",
-		path:          "/health",
-		handler:       service.ReadAuthMiddleware(service.HealthCheckHandler),
-		checkResponse: &checkUnauthorized,
+		method:  "GET",
+		path:    "/health",
+		handler: service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler),
 		header: map[string]string{
 			"X-SSL-Client-Verify": "SUCCESS",
 			"X-SSL-Client-Dn":     "CN=writer",
@@ -293,7 +292,7 @@ func TestService_AuthMiddleware_OIDC(t *testing.T) {
 		testRequest(t, &TestRequest{
 			method:  "GET",
 			path:    "/health",
-			handler: service.AuthMiddleware(service.HealthCheckHandler),
+			handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 			header: map[string]string{
 				"Authorization": "Bearer " + token,
 			},
@@ -311,7 +310,7 @@ func TestService_AuthMiddleware_OIDC(t *testing.T) {
 		testRequest(t, &TestRequest{
 			method:        "GET",
 			path:          "/health",
-			handler:       service.AuthMiddleware(service.HealthCheckHandler),
+			handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 			checkResponse: &checkUnauthorized,
 			header: map[string]string{
 				"Authorization": "Bearer " + token,
@@ -325,7 +324,7 @@ func TestService_AuthMiddleware_OIDC(t *testing.T) {
 		testRequest(t, &TestRequest{
 			method:        "GET",
 			path:          "/health",
-			handler:       service.AuthMiddleware(service.HealthCheckHandler),
+			handler:       service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 			checkResponse: &checkUnauthorized,
 			header: map[string]string{
 				"Authorization": "Bearer not-a-valid-jwt",
@@ -339,10 +338,101 @@ func TestService_AuthMiddleware_OIDC(t *testing.T) {
 		testRequest(t, &TestRequest{
 			method:  "GET",
 			path:    "/health",
-			handler: service.AuthMiddleware(service.HealthCheckHandler),
+			handler: service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler),
 			header: map[string]string{
 				"Authorization": "Bearer " + service.APIToken,
 			},
 		})
+	})
+}
+
+func TestService_RequireScope_OIDC(t *testing.T) {
+	t.Parallel()
+
+	m := oidctest.StartMockOIDC(t)
+	_, validator := oidctest.NewValidator(t, oidc.Config{
+		AllowInsecure: true,
+		Providers: map[string]*oidc.ProviderConfig{
+			"test": {
+				Issuer:   m.Issuer(),
+				Audience: m.Config().ClientID,
+				Rules: []oidc.Rule{
+					{BoundSubject: []string{"builder"}, Scopes: []oidc.Scope{oidc.ScopeWrite}},
+					{BoundSubject: []string{"ops"}, Scopes: []oidc.Scope{oidc.ScopeAdmin}},
+					{BoundSubject: []string{"reader"}, Scopes: []oidc.Scope{oidc.ScopeRead}},
+				},
+			},
+		},
+	})
+
+	service := createTestService(t)
+	t.Cleanup(service.Close)
+	service.Pool.Close()
+	service.OIDCValidator = validator
+	service.APIToken = "static-api-token-at-least-36-chars-long"
+
+	bearer := func(sub string) map[string]string {
+		return map[string]string{"Authorization": "Bearer " + oidctest.SignToken(t, m, jwt.MapClaims{"sub": sub})}
+	}
+	static := map[string]string{"Authorization": "Bearer " + service.APIToken}
+
+	expect := func(code int) *func(*testing.T, *httptest.ResponseRecorder) {
+		f := func(t *testing.T, w *httptest.ResponseRecorder) {
+			t.Helper()
+
+			if w.Code != code {
+				t.Errorf("status = %d, want %d", w.Code, code)
+			}
+		}
+
+		return &f
+	}
+
+	cases := []struct {
+		name   string
+		scope  oidc.Scope
+		header map[string]string
+		code   int
+	}{
+		{"builder may write", oidc.ScopeWrite, bearer("builder"), http.StatusOK},
+		{"builder may not admin", oidc.ScopeAdmin, bearer("builder"), http.StatusForbidden},
+		{"ops may admin", oidc.ScopeAdmin, bearer("ops"), http.StatusOK},
+		{"ops may not write", oidc.ScopeWrite, bearer("ops"), http.StatusForbidden},
+		{"reader may not write", oidc.ScopeWrite, bearer("reader"), http.StatusForbidden},
+		{"static token may admin", oidc.ScopeAdmin, static, http.StatusOK},
+		{"static token may write", oidc.ScopeWrite, static, http.StatusOK},
+		// Read proxy is gated once OIDC is configured with a read rule.
+		{"reader may read", oidc.ScopeRead, bearer("reader"), http.StatusOK},
+		{"writer implies read", oidc.ScopeRead, bearer("builder"), http.StatusOK},
+		{"anonymous may not read", oidc.ScopeRead, nil, http.StatusUnauthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			testRequest(t, &TestRequest{
+				method:        "GET",
+				path:          "/health",
+				handler:       service.RequireScope(tc.scope, service.HealthCheckHandler),
+				header:        tc.header,
+				checkResponse: expect(tc.code),
+			})
+		})
+	}
+}
+
+func TestService_ReadScope_PublicByDefault(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	t.Cleanup(service.Close)
+	service.Pool.Close()
+
+	// No read rules anywhere: reads stay public so plain Nix substituters work.
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/health",
+		handler: service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler),
 	})
 }

--- a/server/client_integration_test.go
+++ b/server/client_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Mic92/niks3/client"
 	"github.com/Mic92/niks3/server"
+	"github.com/Mic92/niks3/server/oidc"
 	"github.com/klauspost/compress/zstd"
 	minio "github.com/minio/minio-go/v7"
 )
@@ -294,8 +295,8 @@ func TestClientIntegration(t *testing.T) {
 
 	// Test garbage collection
 	t.Log("Testing garbage collection...")
-	mux.HandleFunc("DELETE /api/closures", testService.AuthMiddleware(testService.CleanupClosuresOlder))
-	mux.HandleFunc("GET /api/gc/status", testService.AuthMiddleware(testService.GCStatusHandler))
+	mux.HandleFunc("DELETE /api/closures", testService.RequireScope(oidc.ScopeWrite, testService.CleanupClosuresOlder))
+	mux.HandleFunc("GET /api/gc/status", testService.RequireScope(oidc.ScopeWrite, testService.GCStatusHandler))
 
 	c, err := client.NewClient(ctx, ts.URL, testAuthToken)
 	ok(t, err)
@@ -620,9 +621,9 @@ func TestPinProtectsFromGC(t *testing.T) {
 
 	mux := http.NewServeMux()
 	registerTestHandlers(mux, testService)
-	mux.HandleFunc("POST /api/pins/{name}", testService.AuthMiddleware(testService.CreatePinHandler))
-	mux.HandleFunc("DELETE /api/closures", testService.AuthMiddleware(testService.CleanupClosuresOlder))
-	mux.HandleFunc("GET /api/gc/status", testService.AuthMiddleware(testService.GCStatusHandler))
+	mux.HandleFunc("POST /api/pins/{name}", testService.RequireScope(oidc.ScopeWrite, testService.CreatePinHandler))
+	mux.HandleFunc("DELETE /api/closures", testService.RequireScope(oidc.ScopeWrite, testService.CleanupClosuresOlder))
+	mux.HandleFunc("GET /api/gc/status", testService.RequireScope(oidc.ScopeWrite, testService.GCStatusHandler))
 
 	ts := httptest.NewServer(mux)
 

--- a/server/db_conn_test.go
+++ b/server/db_conn_test.go
@@ -1,0 +1,58 @@
+package server_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mic92/niks3/server"
+)
+
+func TestResolveDBConnectionString(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "uri")
+
+	if err := os.WriteFile(file, []byte("postgres://from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lookup := func(env map[string]string) func(string) (string, bool) {
+		return func(k string) (string, bool) {
+			v, ok := env[k]
+
+			return v, ok
+		}
+	}
+
+	tests := []struct {
+		name    string
+		flag    string
+		file    string
+		env     map[string]string
+		want    string
+		wantErr bool
+	}{
+		{name: "flag wins", flag: "postgres://flag", file: file, want: "postgres://flag"},
+		{name: "file when flag empty", file: file, want: "postgres://from-file"},
+		{name: "missing file is an error", file: filepath.Join(dir, "nope"), wantErr: true},
+		{name: "PGHOST allows empty", env: map[string]string{"PGHOST": "db"}, want: ""},
+		{name: "nothing configured", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := server.ResolveDBConnectionString(tc.flag, tc.file, lookup(tc.env))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -58,6 +58,11 @@ func ParseSingleRange(spec string, size int64) (*ByteRange, error) {
 func (br ByteRange) Start() int64 { return br.start }
 func (br ByteRange) End() int64   { return br.end }
 
+// ResolveDBConnectionString is an export of resolveDBConnectionString for tests.
+func ResolveDBConnectionString(flagValue, file string, lookupEnv func(string) (string, bool)) (string, error) {
+	return resolveDBConnectionString(flagValue, file, lookupEnv)
+}
+
 // ServerTLSConfig is an export of serverTLSConfig for tests.
 func ServerTLSConfig(clientCA string) (*tls.Config, error) {
 	return serverTLSConfig(clientCA)

--- a/server/health.go
+++ b/server/health.go
@@ -1,10 +1,16 @@
 package server
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"time"
 )
 
+const readinessTimeout = 2 * time.Second
+
+// HealthCheckHandler is the liveness probe and deliberately has no
+// dependencies, so a Postgres outage does not restart every replica.
 func (s *Service) HealthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
@@ -12,4 +18,20 @@ func (s *Service) HealthCheckHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		slog.Warn("Could not write health check response", "error", err)
 	}
+}
+
+// ReadinessHandler fails while Postgres is unreachable so load balancers stop
+// routing to this instance.
+func (s *Service) ReadinessHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), readinessTimeout)
+	defer cancel()
+
+	if err := s.Pool.Ping(ctx); err != nil {
+		slog.Warn("readiness check failed", "error", err)
+		http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+
+		return
+	}
+
+	s.HealthCheckHandler(w, r)
 }

--- a/server/health_test.go
+++ b/server/health_test.go
@@ -1,6 +1,8 @@
 package server_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -17,5 +19,35 @@ func TestService_healthCheckHandler(t *testing.T) {
 		method:  "GET",
 		path:    "/health",
 		handler: service.HealthCheckHandler,
+	})
+}
+
+func TestService_readinessHandler(t *testing.T) {
+	t.Parallel()
+
+	service := createTestService(t)
+	defer service.Close()
+
+	testRequest(t, &TestRequest{
+		method:  "GET",
+		path:    "/readyz",
+		handler: service.ReadinessHandler,
+	})
+
+	service.Pool.Close()
+
+	notReady := func(t *testing.T, rr *httptest.ResponseRecorder) {
+		t.Helper()
+
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Errorf("expected 503 with closed pool, got %d: %s", rr.Code, rr.Body.String())
+		}
+	}
+
+	testRequest(t, &TestRequest{
+		method:        "GET",
+		path:          "/readyz",
+		handler:       service.ReadinessHandler,
+		checkResponse: &notReady,
 	})
 }

--- a/server/main.go
+++ b/server/main.go
@@ -81,6 +81,35 @@ func readSecretFile(path string) (string, error) {
 	return strings.TrimSpace(string(content)), nil
 }
 
+// resolveDBConnectionString returns "" when PG* variables are set. pgx reads
+// those itself.
+func resolveDBConnectionString(flagValue, file string, lookupEnv func(string) (string, bool)) (string, error) {
+	if flagValue != "" {
+		return flagValue, nil
+	}
+
+	if file != "" {
+		dsn, err := readSecretFile(file)
+		if err != nil {
+			return "", fmt.Errorf("failed to read --db-file: %w", err)
+		}
+
+		if dsn == "" {
+			return "", fmt.Errorf("--db-file %s is empty", file)
+		}
+
+		return dsn, nil
+	}
+
+	for _, k := range []string{"PGHOST", "PGSERVICE"} {
+		if v, _ := lookupEnv(k); v != "" {
+			return "", nil
+		}
+	}
+
+	return "", errors.New("missing database configuration: set --db, --db-file or PGHOST")
+}
+
 const (
 	minAPITokenLength    = 36
 	defaultS3Concurrency = 100
@@ -123,13 +152,17 @@ func parseArgs() (*options, error) {
 
 	maxNarSize := ""
 
+	dbFile := ""
 	s3AccessKeyPath := ""
 	s3SecretKeyPath := ""
 	apiTokenPath := ""
 	s3BucketLookup := ""
 
 	flag.StringVar(&opts.DBConnectionString, "db", getEnvOrDefault("NIKS3_DB", ""),
-		"Postgres connection string, see https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters")
+		"Postgres connection string, see https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters. "+
+			"When empty, libpq PG* environment variables are used")
+	flag.StringVar(&dbFile, "db-file", getEnvOrDefault("NIKS3_DB_FILE", ""),
+		"Path to file containing the Postgres connection string (e.g. a mounted Kubernetes secret)")
 	flag.StringVar(&opts.HTTPAddr, "http-addr", getEnvOrDefault("NIKS3_HTTP_ADDR", ":5751"), "HTTP address to listen on")
 	flag.StringVar(&opts.S3Endpoint, "s3-endpoint", getEnvOrDefault("NIKS3_S3_ENDPOINT", ""), "S3 endpoint")
 	flag.StringVar(&opts.S3AccessKey, "s3-access-key", getEnvOrDefault("NIKS3_S3_ACCESS_KEY", ""), "S3 access key")
@@ -206,11 +239,11 @@ func parseArgs() (*options, error) {
 	flag.Var(signKeyPaths, "sign-key-path", "Path to signing key file (can be specified multiple times)")
 	flag.Parse()
 
-	if opts.DBConnectionString == "" {
-		return nil, errors.New("missing required flag: --db")
-	}
-
 	var err error
+
+	if opts.DBConnectionString, err = resolveDBConnectionString(opts.DBConnectionString, dbFile, os.LookupEnv); err != nil {
+		return nil, err
+	}
 
 	if opts.S3BucketLookup, err = parseBucketLookup(s3BucketLookup); err != nil {
 		return nil, err

--- a/server/matchers_test.go
+++ b/server/matchers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mic92/niks3/api"
 	"github.com/Mic92/niks3/server"
+	"github.com/Mic92/niks3/server/oidc"
 )
 
 // ok fails the test if an err is not nil.
@@ -57,9 +58,9 @@ func waitForGC(tb testing.TB, service *server.Service) api.GCTaskStatus {
 
 // registerTestHandlers registers common test handlers on the given mux.
 func registerTestHandlers(mux *http.ServeMux, testService *server.Service) {
-	mux.HandleFunc("POST /api/pending_closures", testService.AuthMiddleware(testService.CreatePendingClosureHandler))
-	mux.HandleFunc("POST /api/pending_closures/{id}/sign", testService.AuthMiddleware(testService.SignNarinfosHandler))
-	mux.HandleFunc("POST /api/pending_closures/{id}/complete", testService.AuthMiddleware(testService.CommitPendingClosureHandler))
-	mux.HandleFunc("POST /api/multipart/complete", testService.AuthMiddleware(testService.CompleteMultipartUploadHandler))
+	mux.HandleFunc("POST /api/pending_closures", testService.RequireScope(oidc.ScopeWrite, testService.CreatePendingClosureHandler))
+	mux.HandleFunc("POST /api/pending_closures/{id}/sign", testService.RequireScope(oidc.ScopeWrite, testService.SignNarinfosHandler))
+	mux.HandleFunc("POST /api/pending_closures/{id}/complete", testService.RequireScope(oidc.ScopeWrite, testService.CommitPendingClosureHandler))
+	mux.HandleFunc("POST /api/multipart/complete", testService.RequireScope(oidc.ScopeWrite, testService.CompleteMultipartUploadHandler))
 	mux.HandleFunc("GET /health", testService.HealthCheckHandler)
 }

--- a/server/mtls.go
+++ b/server/mtls.go
@@ -37,42 +37,11 @@ func serverTLSConfig(clientCA string) (*tls.Config, error) {
 
 	cfg.ClientCAs = pool
 	// VerifyClientCertIfGiven: anonymous TLS is allowed so bearer-token
-	// auth and public reads still work; AuthMiddleware/ReadAuthMiddleware
-	// decide what an unauthenticated request may do.
+	// auth and public reads still work. RequireScope
+	// decides what an unauthenticated request may do.
 	cfg.ClientAuth = tls.VerifyClientCertIfGiven
 
 	return cfg, nil
-}
-
-// ReadAuthMiddleware gates the read proxy behind mTLS when
-// MTLSBoundSubjectsRead is non-empty. Reads are otherwise public: Nix
-// substituters present no credentials and the cache contents are
-// integrity-signed.
-func (s *Service) ReadAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Checked per-request, not at registration: the bound subject list
-		// may not be set yet when the mux is built (e.g. in tests).
-		if len(s.MTLSBoundSubjectsRead) == 0 {
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		if !s.mtlsCheck(r, s.MTLSBoundSubjectsRead) {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	}
-}
-
-// mtlsAuthenticated reports whether the request carries proxy headers
-// proving a verified mTLS client cert that is allowed by MTLSBoundSubjects.
-// Used for the write API.
-func (s *Service) mtlsAuthenticated(r *http.Request) bool {
-	return s.mtlsCheck(r, s.MTLSBoundSubjects)
 }
 
 // mtlsCheck verifies the client cert (native or proxied) and, if

--- a/server/mtls_test.go
+++ b/server/mtls_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Mic92/niks3/server"
+	"github.com/Mic92/niks3/server/oidc"
 )
 
 // TestService_NativeMTLS exercises the direct-TLS auth path that reads
@@ -53,15 +54,15 @@ func TestService_NativeMTLS(t *testing.T) {
 		}
 	}
 
-	write := service.AuthMiddleware(service.HealthCheckHandler)
-	read := service.ReadAuthMiddleware(service.HealthCheckHandler)
+	write := service.RequireScope(oidc.ScopeWrite, service.HealthCheckHandler)
+	read := service.RequireScope(oidc.ScopeRead, service.HealthCheckHandler)
 
 	check(t, write, "writer", http.StatusOK)
-	check(t, write, "reader", http.StatusUnauthorized)
+	check(t, write, "reader", http.StatusForbidden)
 	check(t, write, "", http.StatusUnauthorized)
 
 	check(t, read, "reader", http.StatusOK)
-	check(t, read, "writer", http.StatusUnauthorized)
+	check(t, read, "writer", http.StatusOK) // write implies read
 	check(t, read, "", http.StatusUnauthorized)
 
 	// Proxy headers ignored under native mTLS.

--- a/server/oidc/claims.go
+++ b/server/oidc/claims.go
@@ -3,8 +3,50 @@ package oidc
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
+
+// Has reports whether the token was granted scope s.
+func (c *ValidatedClaims) Has(s Scope) bool {
+	return slices.Contains(c.Scopes, s)
+}
+
+// matchRules returns the union of scopes of all matching rules, or the first
+// rule's mismatch reason if none match.
+func matchRules(claims map[string]any, rules []Rule) ([]Scope, error) {
+	var (
+		scopes   []Scope
+		firstErr error
+	)
+
+	for _, r := range rules {
+		err := validateBoundClaims(claims, r.BoundClaims)
+		if err == nil {
+			err = validateBoundSubject(claims, r.BoundSubject)
+		}
+
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+
+			continue
+		}
+
+		for _, s := range r.Scopes {
+			if !slices.Contains(scopes, s) {
+				scopes = append(scopes, s)
+			}
+		}
+	}
+
+	if len(scopes) == 0 {
+		return nil, fmt.Errorf("no rule matched: %w", firstErr)
+	}
+
+	return scopes, nil
+}
 
 // validateBoundClaims checks that all bound claims match.
 // All specified claims must match (AND logic).

--- a/server/oidc/config.go
+++ b/server/oidc/config.go
@@ -18,6 +18,29 @@ type Config struct {
 	AllowInsecure bool `json:"allow_insecure,omitempty"`
 }
 
+// Scope is a permission class granted to an authenticated principal.
+type Scope string
+
+const (
+	// ScopeRead allows fetching from the read proxy when it is gated.
+	ScopeRead Scope = "read"
+	// ScopeWrite allows uploading store paths.
+	ScopeWrite Scope = "write"
+	// ScopeAdmin allows GC, pin management and closure deletion.
+	ScopeAdmin Scope = "admin"
+)
+
+func (s Scope) valid() bool {
+	return s == ScopeRead || s == ScopeWrite || s == ScopeAdmin
+}
+
+// Rule grants Scopes to tokens matching BoundClaims and BoundSubject.
+type Rule struct {
+	BoundClaims  map[string][]string `json:"bound_claims,omitempty"`
+	BoundSubject []string            `json:"bound_subject,omitempty"`
+	Scopes       []Scope             `json:"scopes"`
+}
+
 // ProviderConfig configures a single OIDC provider.
 type ProviderConfig struct {
 	// Issuer is the OIDC issuer URL (required).
@@ -41,6 +64,14 @@ type ProviderConfig struct {
 	// Example: ["repo:myorg/*:*"]
 	BoundSubject []string `json:"bound_subject,omitempty"`
 
+	// Scopes granted when the top-level BoundClaims/BoundSubject match.
+	// Defaults to [write]. Mutually exclusive with Rules.
+	Scopes []Scope `json:"scopes,omitempty"`
+
+	// Rules grant scopes per matching rule (union). When set, the
+	// top-level BoundClaims/BoundSubject/Scopes must be empty.
+	Rules []Rule `json:"rules,omitempty"`
+
 	// CAFile and BearerTokenFile are used when fetching discovery/JWKS,
 	// e.g. from a Kubernetes API server (private CA, authenticated).
 	CAFile          string `json:"ca_file,omitempty"`
@@ -53,6 +84,52 @@ type ProviderConfig struct {
 // Name returns the provider name.
 func (p *ProviderConfig) Name() string {
 	return p.name
+}
+
+// effectiveRules folds the legacy top-level bound_* fields into a rule list.
+func (p *ProviderConfig) effectiveRules() []Rule {
+	if len(p.Rules) > 0 {
+		return p.Rules
+	}
+
+	scopes := p.Scopes
+	if len(scopes) == 0 {
+		scopes = []Scope{ScopeWrite}
+	}
+
+	return []Rule{{BoundClaims: p.BoundClaims, BoundSubject: p.BoundSubject, Scopes: scopes}}
+}
+
+func validateScopes(scopes []Scope) error {
+	for _, s := range scopes {
+		if !s.valid() {
+			return fmt.Errorf("unknown scope %q (want read, write or admin)", s)
+		}
+	}
+
+	return nil
+}
+
+func (p *ProviderConfig) validateRules() error {
+	if len(p.Rules) == 0 {
+		return validateScopes(p.Scopes)
+	}
+
+	if len(p.BoundClaims) > 0 || len(p.BoundSubject) > 0 || len(p.Scopes) > 0 {
+		return errors.New("rules cannot be combined with top-level bound_claims/bound_subject/scopes")
+	}
+
+	for i, r := range p.Rules {
+		if len(r.Scopes) == 0 {
+			return fmt.Errorf("rules[%d]: scopes must not be empty", i)
+		}
+
+		if err := validateScopes(r.Scopes); err != nil {
+			return fmt.Errorf("rules[%d]: %w", i, err)
+		}
+	}
+
+	return nil
 }
 
 // LoadConfig loads OIDC configuration from a JSON file.
@@ -107,6 +184,10 @@ func (c *Config) validate() error {
 
 		if provider.Audience == "" {
 			return fmt.Errorf("provider %q: missing audience", name)
+		}
+
+		if err := provider.validateRules(); err != nil {
+			return fmt.Errorf("provider %q: %w", name, err)
 		}
 
 		// Check for duplicate issuers

--- a/server/oidc/config.go
+++ b/server/oidc/config.go
@@ -41,6 +41,11 @@ type ProviderConfig struct {
 	// Example: ["repo:myorg/*:*"]
 	BoundSubject []string `json:"bound_subject,omitempty"`
 
+	// CAFile and BearerTokenFile are used when fetching discovery/JWKS,
+	// e.g. from a Kubernetes API server (private CA, authenticated).
+	CAFile          string `json:"ca_file,omitempty"`
+	BearerTokenFile string `json:"bearer_token_file,omitempty"`
+
 	// name is set from the map key during config loading
 	name string
 }

--- a/server/oidc/kubernetes_test.go
+++ b/server/oidc/kubernetes_test.go
@@ -1,0 +1,147 @@
+package oidc_test
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/server/oidc"
+	"github.com/Mic92/niks3/server/oidc/oidctest"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/oauth2-proxy/mockoidc"
+)
+
+// kubeAPIServer mimics the Kubernetes issuer: private CA, discovery and JWKS
+// require authentication.
+func kubeAPIServer(t *testing.T, kp *mockoidc.Keypair, wantBearer string) *httptest.Server {
+	t.Helper()
+
+	jwks, err := kp.JWKS()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	auth := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer "+wantBearer {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+				return
+			}
+
+			next(w, r)
+		}
+	}
+	mux.HandleFunc("/.well-known/openid-configuration", auth(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srv.URL,
+			"jwks_uri":                              srv.URL + "/openid/v1/jwks",
+			"response_types_supported":              []string{"id_token"},
+			"subject_types_supported":               []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	}))
+	mux.HandleFunc("/openid/v1/jwks", auth(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+		_, _ = w.Write(jwks)
+	}))
+
+	srv = httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestValidateToken_KubernetesServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	kp, err := mockoidc.NewKeypair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const discoveryToken = "niks3-own-serviceaccount-token"
+
+	srv := kubeAPIServer(t, kp, discoveryToken)
+	dir := t.TempDir()
+
+	caFile := filepath.Join(dir, "ca.crt")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+
+	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte(discoveryToken+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config := oidc.Config{
+		Providers: map[string]*oidc.ProviderConfig{
+			"kubernetes": {
+				Issuer:          srv.URL,
+				Audience:        "niks3",
+				BoundSubject:    []string{"system:serviceaccount:ci:*"},
+				CAFile:          caFile,
+				BearerTokenFile: tokenFile,
+			},
+		},
+	}
+	ctx, validator := oidctest.NewValidator(t, config)
+
+	sign := func(sub string) string {
+		tok, err := kp.SignJWT(jwt.MapClaims{
+			"iss": srv.URL,
+			"aud": []string{"niks3"},
+			"sub": sub,
+			"iat": time.Now().Unix(),
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return tok
+	}
+
+	claims, err := validator.ValidateToken(ctx, sign("system:serviceaccount:ci:builder"))
+	if err != nil {
+		t.Fatalf("expected pod in ci namespace to be allowed: %v", err)
+	}
+
+	if claims.Provider != "kubernetes" {
+		t.Errorf("provider = %q", claims.Provider)
+	}
+
+	if _, err := validator.ValidateToken(ctx, sign("system:serviceaccount:default:web")); err == nil {
+		t.Fatal("expected pod outside bound namespace to be rejected")
+	}
+}
+
+func TestNewValidator_KubernetesRequiresCA(t *testing.T) {
+	t.Parallel()
+
+	kp, err := mockoidc.NewKeypair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := kubeAPIServer(t, kp, "x")
+
+	cfg := &oidc.Config{Providers: map[string]*oidc.ProviderConfig{
+		"kubernetes": {Issuer: srv.URL, Audience: "niks3"},
+	}}
+
+	if _, err := oidc.NewValidator(t.Context(), cfg); err == nil {
+		t.Fatal("expected discovery against private CA without ca_file to fail")
+	}
+}

--- a/server/oidc/scopes_test.go
+++ b/server/oidc/scopes_test.go
@@ -1,0 +1,109 @@
+package oidc_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Mic92/niks3/server/oidc"
+	"github.com/Mic92/niks3/server/oidc/oidctest"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestScopes_LegacyProviderDefaultsToWrite(t *testing.T) {
+	t.Parallel()
+
+	m := oidctest.StartMockOIDC(t)
+	ctx, v := oidctest.NewValidator(t, oidc.Config{
+		AllowInsecure: true,
+		Providers: map[string]*oidc.ProviderConfig{
+			"test": {Issuer: m.Issuer(), Audience: m.Config().ClientID, BoundSubject: []string{"ci:*"}},
+		},
+	})
+
+	claims, err := v.ValidateToken(ctx, oidctest.SignToken(t, m, jwt.MapClaims{"sub": "ci:a"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !claims.Has(oidc.ScopeWrite) || claims.Has(oidc.ScopeAdmin) || claims.Has(oidc.ScopeRead) {
+		t.Errorf("scopes = %v, want [write]", claims.Scopes)
+	}
+}
+
+func TestScopes_Rules(t *testing.T) {
+	t.Parallel()
+
+	m := oidctest.StartMockOIDC(t)
+	ctx, v := oidctest.NewValidator(t, oidc.Config{
+		AllowInsecure: true,
+		Providers: map[string]*oidc.ProviderConfig{
+			"test": {
+				Issuer:   m.Issuer(),
+				Audience: m.Config().ClientID,
+				Rules: []oidc.Rule{
+					{BoundSubject: []string{"sa:ci:*"}, Scopes: []oidc.Scope{oidc.ScopeWrite}},
+					{BoundSubject: []string{"sa:ops:gc"}, Scopes: []oidc.Scope{oidc.ScopeAdmin}},
+					{BoundClaims: map[string][]string{"team": {"nix"}}, Scopes: []oidc.Scope{oidc.ScopeRead}},
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		claims jwt.MapClaims
+		want   []oidc.Scope
+	}{
+		{jwt.MapClaims{"sub": "sa:ci:builder"}, []oidc.Scope{oidc.ScopeWrite}},
+		{jwt.MapClaims{"sub": "sa:ops:gc"}, []oidc.Scope{oidc.ScopeAdmin}},
+		// Rules union.
+		{jwt.MapClaims{"sub": "sa:ci:builder", "team": "nix"}, []oidc.Scope{oidc.ScopeRead, oidc.ScopeWrite}},
+		{jwt.MapClaims{"sub": "sa:web:x"}, nil},
+	}
+
+	for _, tc := range tests {
+		got, err := v.ValidateToken(ctx, oidctest.SignToken(t, m, tc.claims))
+		if tc.want == nil {
+			if err == nil {
+				t.Errorf("%v: expected rejection, got scopes %v", tc.claims, got.Scopes)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("%v: %v", tc.claims, err)
+
+			continue
+		}
+
+		scopes := slices.Clone(got.Scopes)
+		slices.Sort(scopes)
+
+		if !slices.Equal(scopes, tc.want) {
+			t.Errorf("%v: scopes = %v, want %v", tc.claims, scopes, tc.want)
+		}
+	}
+}
+
+func TestScopes_ConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	base := func(p *oidc.ProviderConfig) oidc.Config {
+		p.Issuer = "https://issuer.example"
+		p.Audience = "aud"
+
+		return oidc.Config{Providers: map[string]*oidc.ProviderConfig{"p": p}}
+	}
+
+	bad := []oidc.Config{
+		base(&oidc.ProviderConfig{Scopes: []oidc.Scope{"root"}}),
+		base(&oidc.ProviderConfig{BoundSubject: []string{"x"}, Rules: []oidc.Rule{{Scopes: []oidc.Scope{oidc.ScopeWrite}}}}),
+		base(&oidc.ProviderConfig{Rules: []oidc.Rule{{BoundSubject: []string{"x"}}}}),
+	}
+
+	for i, cfg := range bad {
+		if _, err := oidc.LoadConfig(oidctest.WriteConfig(t, cfg)); err == nil {
+			t.Errorf("config %d: expected validation error", i)
+		}
+	}
+}

--- a/server/oidc/validator.go
+++ b/server/oidc/validator.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
@@ -63,6 +64,8 @@ type ValidatedClaims struct {
 	Issuer string
 	// Provider is the provider name from config
 	Provider string
+	// Scopes is the union of scopes of all matching rules.
+	Scopes []Scope
 	// RawClaims contains all claims for logging/debugging
 	RawClaims map[string]any
 }
@@ -158,6 +161,19 @@ func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 	return v, nil
 }
 
+// GrantsScope reports whether any configured rule can grant s.
+func (v *Validator) GrantsScope(s Scope) bool {
+	for _, p := range v.config.Providers {
+		for _, r := range p.effectiveRules() {
+			if slices.Contains(r.Scopes, s) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // AudienceForIssuer returns the configured audience for the given issuer URL,
 // and whether a provider is configured for that issuer.
 func (v *Validator) AudienceForIssuer(issuer string) (string, bool) {
@@ -200,24 +216,12 @@ func (v *Validator) ValidateToken(ctx context.Context, tokenString string) (*Val
 			}
 		}
 
-		// Validate bound claims (our custom authorization logic)
-		if err := validateBoundClaims(claims, pv.config.BoundClaims); err != nil {
-			slog.Debug("Bound claims validation failed", "provider", pv.config.Name(), "error", err)
+		scopes, err := matchRules(claims, pv.config.effectiveRules())
+		if err != nil {
+			slog.Debug("No rule matched", "provider", pv.config.Name(), "error", err)
 
 			return nil, &ValidationError{
-				Reason:         fmt.Sprintf("bound claims validation failed: %v", err),
-				Provider:       pv.config.Name(),
-				Claims:         claims,
-				TriedProviders: triedProviders,
-			}
-		}
-
-		// Validate bound subject
-		if err := validateBoundSubject(claims, pv.config.BoundSubject); err != nil {
-			slog.Debug("Bound subject validation failed", "provider", pv.config.Name(), "error", err)
-
-			return nil, &ValidationError{
-				Reason:         fmt.Sprintf("bound subject validation failed: %v", err),
+				Reason:         err.Error(),
 				Provider:       pv.config.Name(),
 				Claims:         claims,
 				TriedProviders: triedProviders,
@@ -228,6 +232,7 @@ func (v *Validator) ValidateToken(ctx context.Context, tokenString string) (*Val
 			Subject:   idToken.Subject,
 			Issuer:    issuer,
 			Provider:  pv.config.Name(),
+			Scopes:    scopes,
 			RawClaims: claims,
 		}, nil
 	}

--- a/server/oidc/validator.go
+++ b/server/oidc/validator.go
@@ -2,9 +2,14 @@ package oidc
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"os"
+	"strings"
 
 	gooidc "github.com/coreos/go-oidc/v3/oidc"
 )
@@ -62,6 +67,58 @@ type ValidatedClaims struct {
 	RawClaims map[string]any
 }
 
+// bearerFileTransport re-reads the token per request to follow rotation.
+type bearerFileTransport struct {
+	path string
+	base http.RoundTripper
+}
+
+func (t *bearerFileTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := os.ReadFile(t.path)
+	if err != nil {
+		return nil, fmt.Errorf("reading bearer token file: %w", err)
+	}
+
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery request: %w", err)
+	}
+
+	return resp, nil
+}
+
+func httpClientFor(p *ProviderConfig) (*http.Client, error) {
+	if p.CAFile == "" && p.BearerTokenFile == "" {
+		return http.DefaultClient, nil
+	}
+
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
+
+	if p.CAFile != "" {
+		pem, err := os.ReadFile(p.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading ca_file: %w", err)
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("ca_file %s contains no certificates", p.CAFile)
+		}
+
+		transport.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	}
+
+	var rt http.RoundTripper = transport
+	if p.BearerTokenFile != "" {
+		rt = &bearerFileTransport{path: p.BearerTokenFile, base: transport}
+	}
+
+	return &http.Client{Transport: rt}, nil
+}
+
 // NewValidator creates a new OIDC validator from config.
 func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 	v := &Validator{
@@ -73,8 +130,13 @@ func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 	for name, providerCfg := range cfg.Providers {
 		slog.Debug("Initializing OIDC provider", "name", name, "issuer", providerCfg.Issuer)
 
-		// Create the OIDC provider (handles discovery and JWKS)
-		provider, err := gooidc.NewProvider(ctx, providerCfg.Issuer)
+		client, err := httpClientFor(providerCfg)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", name, err)
+		}
+
+		// go-oidc reuses this context's client for later JWKS fetches.
+		provider, err := gooidc.NewProvider(gooidc.ClientContext(ctx, client), providerCfg.Issuer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize OIDC provider for %s: %w", providerCfg.Issuer, err)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"crypto/subtle"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -145,67 +144,6 @@ const (
 	shutdownTimeout = 10 * time.Second
 )
 
-func (s *Service) AuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// mTLS via reverse proxy. The proxy is responsible for overriding
-		// these headers on every request; we only trust them because the
-		// operator opted in.
-		if s.mtlsAuthenticated(r) {
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		authHeader := r.Header.Get("Authorization")
-		if authHeader == "" {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-
-			return
-		}
-
-		const bearerPrefix = "Bearer "
-		if !strings.HasPrefix(authHeader, bearerPrefix) {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-
-			return
-		}
-
-		token := strings.TrimPrefix(authHeader, bearerPrefix)
-
-		// Try static API token first (faster, no network calls)
-		if s.APIToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(s.APIToken)) == 1 {
-			next.ServeHTTP(w, r)
-
-			return
-		}
-
-		// Fall back to OIDC validation if configured
-		var oidcErr *oidc.ValidationError
-
-		if s.OIDCValidator != nil {
-			claims, err := s.OIDCValidator.ValidateToken(r.Context(), token)
-			if err == nil {
-				slog.Info("OIDC auth successful", "provider", claims.Provider)
-				slog.Debug("OIDC auth details", "subject", claims.Subject)
-				next.ServeHTTP(w, r)
-
-				return
-			}
-			// Store the OIDC error for later logging
-			validationErr := &oidc.ValidationError{}
-			if errors.As(err, &validationErr) {
-				oidcErr = validationErr
-			}
-
-			slog.Debug("OIDC validation failed")
-		}
-
-		// Both static token and OIDC failed - log details for debugging
-		s.logAuthFailure(token, oidcErr)
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-	}
-}
-
 func runServer(opts *options) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbConnectionTimeout)
 	defer cancel()
@@ -311,28 +249,28 @@ func runServer(opts *options) error {
 	mux.HandleFunc("GET /api/cache-config", service.CacheConfigHandler)
 	mux.HandleFunc("GET /api/cache-stats", service.CacheStatsHandler)
 
-	mux.HandleFunc("POST /api/pending_closures", service.AuthMiddleware(service.CreatePendingClosureHandler))
-	mux.HandleFunc("DELETE /api/pending_closures", service.AuthMiddleware(service.CleanupPendingClosuresHandler))
-	mux.HandleFunc("POST /api/pending_closures/{id}/sign", service.AuthMiddleware(service.SignNarinfosHandler))
-	mux.HandleFunc("POST /api/pending_closures/{id}/complete", service.AuthMiddleware(service.CommitPendingClosureHandler))
-	mux.HandleFunc("POST /api/multipart/complete", service.AuthMiddleware(service.CompleteMultipartUploadHandler))
-	mux.HandleFunc("POST /api/uploads/complete", service.AuthMiddleware(service.CompleteUploadHandler))
-	mux.HandleFunc("POST /api/uploads/skipped", service.AuthMiddleware(service.SkippedUploadsHandler))
-	mux.HandleFunc("POST /api/multipart/request-parts", service.AuthMiddleware(service.RequestMorePartsHandler))
-	mux.HandleFunc("HEAD /api/objects/{key...}", service.AuthMiddleware(service.ObjectExistsHandler))
-	mux.HandleFunc("GET /api/closures/{key}", service.AuthMiddleware(service.GetClosureHandler))
-	mux.HandleFunc("DELETE /api/closures", service.AuthMiddleware(service.CleanupClosuresOlder))
-	mux.HandleFunc("GET /api/gc/status", service.AuthMiddleware(service.GCStatusHandler))
-	mux.HandleFunc("GET /api/pins", service.AuthMiddleware(service.ListPinsHandler))
-	mux.HandleFunc("POST /api/pins/{name}", service.AuthMiddleware(service.CreatePinHandler))
-	mux.HandleFunc("DELETE /api/pins/{name}", service.AuthMiddleware(service.DeletePinHandler))
+	mux.HandleFunc("POST /api/pending_closures", service.RequireScope(oidc.ScopeWrite, service.CreatePendingClosureHandler))
+	mux.HandleFunc("DELETE /api/pending_closures", service.RequireScope(oidc.ScopeAdmin, service.CleanupPendingClosuresHandler))
+	mux.HandleFunc("POST /api/pending_closures/{id}/sign", service.RequireScope(oidc.ScopeWrite, service.SignNarinfosHandler))
+	mux.HandleFunc("POST /api/pending_closures/{id}/complete", service.RequireScope(oidc.ScopeWrite, service.CommitPendingClosureHandler))
+	mux.HandleFunc("POST /api/multipart/complete", service.RequireScope(oidc.ScopeWrite, service.CompleteMultipartUploadHandler))
+	mux.HandleFunc("POST /api/uploads/complete", service.RequireScope(oidc.ScopeWrite, service.CompleteUploadHandler))
+	mux.HandleFunc("POST /api/uploads/skipped", service.RequireScope(oidc.ScopeWrite, service.SkippedUploadsHandler))
+	mux.HandleFunc("POST /api/multipart/request-parts", service.RequireScope(oidc.ScopeWrite, service.RequestMorePartsHandler))
+	mux.HandleFunc("HEAD /api/objects/{key...}", service.RequireScope(oidc.ScopeWrite, service.ObjectExistsHandler))
+	mux.HandleFunc("GET /api/closures/{key}", service.RequireScope(oidc.ScopeWrite, service.GetClosureHandler))
+	mux.HandleFunc("DELETE /api/closures", service.RequireScope(oidc.ScopeAdmin, service.CleanupClosuresOlder))
+	mux.HandleFunc("GET /api/gc/status", service.RequireScope(oidc.ScopeAdmin, service.GCStatusHandler))
+	mux.HandleFunc("GET /api/pins", service.RequireScope(oidc.ScopeWrite, service.ListPinsHandler))
+	mux.HandleFunc("POST /api/pins/{name}", service.RequireScope(oidc.ScopeWrite, service.CreatePinHandler))
+	mux.HandleFunc("DELETE /api/pins/{name}", service.RequireScope(oidc.ScopeAdmin, service.DeletePinHandler))
 
 	if opts.EnableReadProxy {
 		service.EnableReadProxy = true
 		service.ReadRedirectTTL = opts.ReadRedirectTTL
 		// Register without method prefix to avoid ServeMux conflicts with
 		// auto-generated HEAD routes. The handler rejects non-GET/HEAD itself.
-		mux.HandleFunc("/{path...}", service.ReadAuthMiddleware(service.ReadProxyHandler))
+		mux.HandleFunc("/{path...}", service.RequireScope(oidc.ScopeRead, service.ReadProxyHandler))
 		slog.Info("Read proxy enabled — serving cache objects from S3")
 
 		if opts.ReadRedirectTTL > 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -305,6 +305,8 @@ func runServer(opts *options) error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", service.HealthCheckHandler)
+	mux.HandleFunc("GET /healthz", service.HealthCheckHandler)
+	mux.HandleFunc("GET /readyz", service.ReadinessHandler)
 	mux.Handle("GET /metrics", service.Metrics.Handler())
 	mux.HandleFunc("GET /api/cache-config", service.CacheConfigHandler)
 	mux.HandleFunc("GET /api/cache-stats", service.CacheStatsHandler)


### PR DESCRIPTION
Adds a Helm chart and lets pods push with their Kubernetes service account token (OIDC against the API server issuer, hence the new ca_file/bearer_token_file options). The server gains /readyz, --db-file and PG* env fallback.

OIDC principals are now scoped read/write/admin. Breaking: existing providers default to write and need admin added for GC/pin deletion.

Covered by a k3s NixOS test. Docs are on the Kubernetes wiki page.