### PR TITLE
feat(push): add --no-closure flag

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	Retry                   RetryConfig                    // Retry configuration for HTTP requests
 	storeDir                string                         // Cached Nix store directory (e.g., "/nix/store")
 	VerifyS3Integrity       bool                           // Enable S3 integrity checking when creating pending closures
+	NoClosure               bool                           // Upload exactly the given paths instead of expanding their closures
 	DebugHTTP               bool                           // Enable HTTP request/response debug logging
 	S3RateLimiter           *ratelimit.AdaptiveRateLimiter // Rate limiter for S3 presigned URL uploads
 	ServerRateLimiter       *ratelimit.AdaptiveRateLimiter // Rate limiter for niks3 server API calls

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -21,6 +21,12 @@ var PartSizeForNAR = partSizeForNAR //nolint:gochecknoglobals // test-only re-ex
 // FilterOversizedClosures re-exports filterOversizedClosures for the external test package.
 var FilterOversizedClosures = filterOversizedClosures //nolint:gochecknoglobals // test-only re-export
 
+// ChunkStorePaths re-exports chunkStorePaths for the external test package.
+var ChunkStorePaths = chunkStorePaths //nolint:gochecknoglobals // test-only re-export
+
+// MaxPathInfoArgBytes re-exports the path-info argument budget for tests.
+const MaxPathInfoArgBytes = maxPathInfoArgBytes
+
 // MultipartPartSize re-exports the default part size for tests.
 const MultipartPartSize = multipartPartSize
 

--- a/client/max_nar_size_test.go
+++ b/client/max_nar_size_test.go
@@ -25,7 +25,7 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("no limit keeps everything", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 0)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 0, false)
 		if skipped.Paths != 0 || skipped.NarBytes != 0 {
 			t.Errorf("skipped = %+v, want none", skipped)
 		}
@@ -38,7 +38,7 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("closure with oversized dependency is skipped", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 2000)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper, small}, pathInfos, 2000, false)
 		if skipped.Paths != 2 || skipped.NarBytes != 5100 {
 			t.Errorf("skipped = %+v, want 2 paths / 5100 bytes", skipped)
 		}
@@ -55,13 +55,34 @@ func TestFilterOversizedClosures(t *testing.T) {
 	t.Run("all closures skipped", func(t *testing.T) {
 		t.Parallel()
 
-		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper}, pathInfos, 50)
+		kept, infos, skipped := client.FilterOversizedClosures([]string{wrapper}, pathInfos, 50, false)
 		if skipped.Paths != 3 || skipped.NarBytes != 6100 {
 			t.Errorf("skipped = %+v, want 3 paths / 6100 bytes", skipped)
 		}
 
 		if len(kept) != 0 || len(infos) != 0 {
 			t.Errorf("kept = %v, infos = %v, want none", kept, infos)
+		}
+	})
+
+	t.Run("no-closure judges each path on its own size", func(t *testing.T) {
+		t.Parallel()
+
+		// wrapper references the oversized image but is uploaded on its own,
+		// so it must not inherit the dependency's size.
+		roots := []string{wrapper, small, image}
+
+		kept, infos, skipped := client.FilterOversizedClosures(roots, pathInfos, 2000, true)
+		if !slices.Equal(kept, []string{wrapper, small}) {
+			t.Errorf("kept = %v, want %v", kept, []string{wrapper, small})
+		}
+
+		if skipped.Paths != 1 || skipped.NarBytes != 5000 {
+			t.Errorf("skipped = %+v, want 1 path / 5000 bytes", skipped)
+		}
+
+		if len(infos) != 2 || infos[wrapper] == nil || infos[small] == nil {
+			t.Errorf("pruned infos = %v, want %s and %s", infos, wrapper, small)
 		}
 	})
 }

--- a/client/nixstore.go
+++ b/client/nixstore.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -220,10 +222,75 @@ type RealisationInfo struct {
 	DependentRealisations map[string]string `json:"dependentRealisations,omitempty"` //nolint:tagliatelle
 }
 
+// maxPathInfoArgBytes bounds the store paths per `nix path-info` call, well
+// under the execve argument limit (~256 KiB on macOS) shared with the environment.
+const maxPathInfoArgBytes = 128 * 1024
+
 // GetPathInfoRecursive queries Nix for path info including all dependencies.
 func GetPathInfoRecursive(ctx context.Context, storePaths []string, nixEnv []string) (map[string]*PathInfo, error) {
+	return getPathInfo(ctx, storePaths, nixEnv, true)
+}
+
+// GetPathInfo queries Nix for exactly the given store paths, without
+// descending into their references.
+func GetPathInfo(ctx context.Context, storePaths []string, nixEnv []string) (map[string]*PathInfo, error) {
+	return getPathInfo(ctx, storePaths, nixEnv, false)
+}
+
+// getPathInfo runs `nix path-info` in chunks and merges the results. Paths
+// repeated across chunks resolve identically, so overwrites are harmless.
+func getPathInfo(ctx context.Context, storePaths []string, nixEnv []string, recursive bool) (map[string]*PathInfo, error) {
+	result := make(map[string]*PathInfo, len(storePaths))
+
+	for chunk := range chunkStorePaths(storePaths, maxPathInfoArgBytes) {
+		infos, err := runPathInfo(ctx, chunk, nixEnv, recursive)
+		if err != nil {
+			return nil, err
+		}
+
+		maps.Copy(result, infos)
+	}
+
+	return result, nil
+}
+
+// chunkStorePaths splits storePaths into groups under maxBytes. An oversized
+// path still gets its own chunk rather than being dropped.
+func chunkStorePaths(storePaths []string, maxBytes int) iter.Seq[[]string] {
+	return func(yield func([]string) bool) {
+		start := 0
+		size := 0
+
+		for i, path := range storePaths {
+			// +1 for the NUL separator execve adds between arguments.
+			cost := len(path) + 1
+			if i > start && size+cost > maxBytes {
+				if !yield(storePaths[start:i]) {
+					return
+				}
+
+				start = i
+				size = 0
+			}
+
+			size += cost
+		}
+
+		if start < len(storePaths) {
+			yield(storePaths[start:])
+		}
+	}
+}
+
+func runPathInfo(ctx context.Context, storePaths []string, nixEnv []string, recursive bool) (map[string]*PathInfo, error) {
 	args := make([]string, 0, 6+len(storePaths))
-	args = append(args, "--extra-experimental-features", "nix-command", "path-info", "--recursive", "--json", "--")
+	args = append(args, "--extra-experimental-features", "nix-command", "path-info")
+
+	if recursive {
+		args = append(args, "--recursive")
+	}
+
+	args = append(args, "--json", "--")
 	args = append(args, storePaths...)
 
 	cmd := exec.CommandContext(ctx, "nix", args...)

--- a/client/no_closure_test.go
+++ b/client/no_closure_test.go
@@ -1,0 +1,235 @@
+package client_test
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+// Store path hashes must be 32 chars; narHash values are real base64 SHA-256
+// digests so getNARKey can convert them to Nix32.
+const (
+	pathA = "/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-app"
+	pathB = "/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb-libfoo"
+	pathC = "/nix/store/cccccccccccccccccccccccccccccccc-gcc"
+
+	hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	hashC = "cccccccccccccccccccccccccccccccc"
+)
+
+// pathInfoFixture builds A -> B plus a standalone C, standing in for a
+// build-only dependency that nothing in the runtime graph points at.
+func pathInfoFixture(t *testing.T) map[string]*client.PathInfo {
+	t.Helper()
+
+	const jsonInput = `{
+		"` + pathA + `": {
+			"narHash": "sha256-ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs=",
+			"narSize": 100,
+			"references": ["` + pathB + `"]
+		},
+		"` + pathB + `": {
+			"narHash": "sha256-PiPoFgA5WUoziU9lZOGxNIu9egCI1CxKy3PurtWcAJ0=",
+			"narSize": 200,
+			"references": []
+		},
+		"` + pathC + `": {
+			"narHash": "sha256-Ln0sA6lQeuJl7PW1NWiFpTOTogKdJBOUmXJloaJa78Y=",
+			"narSize": 300,
+			"references": []
+		}
+	}`
+
+	pathInfos, err := client.ParsePathInfoJSON([]byte(jsonInput))
+	if err != nil {
+		t.Fatalf("parsing fixture path info: %v", err)
+	}
+
+	return pathInfos
+}
+
+// closureByKey indexes prepared closures by their root narinfo key.
+func closureByKey(closures []client.ClosureInfo) map[string]client.ClosureInfo {
+	byKey := make(map[string]client.ClosureInfo, len(closures))
+	for _, c := range closures {
+		byKey[c.NarinfoKey] = c
+	}
+
+	return byKey
+}
+
+// narinfoKeys returns the sorted narinfo object keys of a closure.
+func narinfoKeys(closure client.ClosureInfo) []string {
+	var keys []string
+
+	for _, obj := range closure.Objects {
+		if obj.Type == client.ObjectTypeNarinfo {
+			keys = append(keys, obj.Key)
+		}
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}
+
+func TestPrepareClosuresNoClosure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	pathInfos := pathInfoFixture(t)
+	roots := []string{pathA, pathB, pathC}
+
+	t.Run("closure mode pulls in transitive references", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := client.PrepareClosures(ctx, roots, pathInfos, nil, false)
+		if err != nil {
+			t.Fatalf("PrepareClosures: %v", err)
+		}
+
+		byKey := closureByKey(result.Closures)
+
+		got := narinfoKeys(byKey[hashA+".narinfo"])
+		want := []string{hashA + ".narinfo", hashB + ".narinfo"}
+
+		if !slices.Equal(got, want) {
+			t.Errorf("closure for A = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("no-closure keeps each path self-contained", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := client.PrepareClosures(ctx, roots, pathInfos, nil, true)
+		if err != nil {
+			t.Fatalf("PrepareClosures: %v", err)
+		}
+
+		if len(result.Closures) != len(roots) {
+			t.Fatalf("got %d closures, want %d", len(result.Closures), len(roots))
+		}
+
+		byKey := closureByKey(result.Closures)
+
+		// A references B, but --no-closure must not pull B's objects in:
+		// a reference-closed set would otherwise grow payloads quadratically.
+		for _, tc := range []struct{ name, hash string }{
+			{"A", hashA},
+			{"B", hashB},
+			{"C", hashC},
+		} {
+			closure, ok := byKey[tc.hash+".narinfo"]
+			if !ok {
+				t.Fatalf("no closure for %s", tc.name)
+			}
+
+			got := narinfoKeys(closure)
+			want := []string{tc.hash + ".narinfo"}
+
+			if !slices.Equal(got, want) {
+				t.Errorf("closure for %s = %v, want %v", tc.name, got, want)
+			}
+
+			// narinfo, nar and .ls, and nothing belonging to another path.
+			if len(closure.Objects) != 3 {
+				t.Errorf("closure for %s has %d objects, want 3", tc.name, len(closure.Objects))
+			}
+		}
+	})
+
+	t.Run("no-closure narinfos still record their references", func(t *testing.T) {
+		t.Parallel()
+
+		// GC walks objects.refs from every gcroot, so A's narinfo must still
+		// point at B even though B was uploaded as an independent closure.
+		result, err := client.PrepareClosures(ctx, roots, pathInfos, nil, true)
+		if err != nil {
+			t.Fatalf("PrepareClosures: %v", err)
+		}
+
+		closure := closureByKey(result.Closures)[hashA+".narinfo"]
+
+		var refs []string
+
+		for _, obj := range closure.Objects {
+			if obj.Key == hashA+".narinfo" {
+				refs = obj.Refs
+			}
+		}
+
+		if !slices.Contains(refs, hashB+".narinfo") {
+			t.Errorf("A's narinfo refs = %v, want it to contain %s", refs, hashB+".narinfo")
+		}
+	})
+}
+
+func TestChunkStorePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps a small set in one chunk", func(t *testing.T) {
+		t.Parallel()
+
+		paths := []string{pathA, pathB, pathC}
+
+		chunks := slices.Collect(client.ChunkStorePaths(paths, client.MaxPathInfoArgBytes))
+		if len(chunks) != 1 {
+			t.Fatalf("got %d chunks, want 1", len(chunks))
+		}
+
+		if !slices.Equal(chunks[0], paths) {
+			t.Errorf("chunk = %v, want %v", chunks[0], paths)
+		}
+	})
+
+	t.Run("splits on the byte budget and preserves every path", func(t *testing.T) {
+		t.Parallel()
+
+		// Budget fits two paths per chunk: each costs len(path)+1.
+		budget := 2 * (len(pathA) + 1)
+		paths := []string{pathA, pathA, pathA, pathA, pathA}
+
+		chunks := slices.Collect(client.ChunkStorePaths(paths, budget))
+		if len(chunks) != 3 {
+			t.Fatalf("got %d chunks, want 3", len(chunks))
+		}
+
+		var total int
+
+		for _, chunk := range chunks {
+			if len(chunk) > 2 {
+				t.Errorf("chunk of %d paths exceeds budget of 2", len(chunk))
+			}
+
+			total += len(chunk)
+		}
+
+		if total != len(paths) {
+			t.Errorf("chunks cover %d paths, want %d", total, len(paths))
+		}
+	})
+
+	t.Run("emits an oversized path rather than dropping it", func(t *testing.T) {
+		t.Parallel()
+
+		long := "/nix/store/" + strings.Repeat("x", 500)
+
+		chunks := slices.Collect(client.ChunkStorePaths([]string{long}, 10))
+		if len(chunks) != 1 || len(chunks[0]) != 1 || chunks[0][0] != long {
+			t.Errorf("chunks = %v, want the single oversized path", chunks)
+		}
+	})
+
+	t.Run("handles an empty input", func(t *testing.T) {
+		t.Parallel()
+
+		chunks := slices.Collect(client.ChunkStorePaths(nil, client.MaxPathInfoArgBytes))
+		if len(chunks) != 0 {
+			t.Errorf("got %d chunks, want none", len(chunks))
+		}
+	})
+}

--- a/client/upload.go
+++ b/client/upload.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -108,7 +110,14 @@ type PrepareClosuresResult struct {
 // Build logs are automatically discovered for output paths and included by default.
 // Realisations are queried for CA derivations and included automatically.
 // topLevelPaths specifies which paths are closure roots - one ClosureInfo is created per top-level path.
-func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[string]*PathInfo, nixEnv []string) (*PrepareClosuresResult, error) {
+// With noClosure set, each ClosureInfo carries only its own path's objects instead of its whole closure.
+func PrepareClosures(
+	ctx context.Context,
+	topLevelPaths []string,
+	pathInfos map[string]*PathInfo,
+	nixEnv []string,
+	noClosure bool,
+) (*PrepareClosuresResult, error) {
 	pathInfoByHash := make(map[string]*PathInfo)
 	narKeyToHash := make(map[string]string)
 	logPathsByKey := make(map[string]string)
@@ -233,7 +242,7 @@ func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[
 	}
 
 	// Second pass: compute closure membership for each top-level path
-	closureMembership := computeClosureMembership(topLevelPaths, pathInfos)
+	closureMembership := computeClosureMembership(topLevelPaths, pathInfos, noClosure)
 
 	// Third pass: create one ClosureInfo per top-level path with only its reachable objects
 	closures := make([]ClosureInfo, 0, len(topLevelPaths))
@@ -247,13 +256,12 @@ func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[
 
 		narinfoKey := topLevelHash + ".narinfo"
 
-		// Collect objects only for paths reachable from this top-level path
+		// Iterate the reachable set, not allObjects: it is the smaller side,
+		// which matters with --no-closure where root count scales with paths.
 		var closureObjects []ObjectWithRefs
 
-		reachable := closureMembership[topLevelPath]
-
-		for storePath, objects := range allObjects {
-			if reachable[storePath] {
+		for storePath := range closureMembership[topLevelPath] {
+			if objects, ok := allObjects[storePath]; ok {
 				closureObjects = append(closureObjects, objects...)
 			}
 		}
@@ -274,12 +282,21 @@ func PrepareClosures(ctx context.Context, topLevelPaths []string, pathInfos map[
 }
 
 // computeClosureMembership returns, for each top-level path, the set of store
-// paths reachable from it via references.
-func computeClosureMembership(topLevelPaths []string, pathInfos map[string]*PathInfo) map[string]map[string]bool {
-	closureMembership := make(map[string]map[string]bool) // topLevelPath -> set of reachable paths
+// paths reachable from it via references. With noClosure, each path maps to
+// just itself: the requested set is often reference-closed, so traversal must
+// be suppressed explicitly.
+func computeClosureMembership(topLevelPaths []string, pathInfos map[string]*PathInfo, noClosure bool) map[string]map[string]bool {
+	closureMembership := make(map[string]map[string]bool, len(topLevelPaths)) // topLevelPath -> set of reachable paths
 
 	for _, topLevelPath := range topLevelPaths {
 		reachable := make(map[string]bool)
+
+		if noClosure {
+			reachable[topLevelPath] = true
+			closureMembership[topLevelPath] = reachable
+
+			continue
+		}
 
 		var visit func(string)
 
@@ -318,12 +335,18 @@ type skippedUploads struct {
 // top-level paths, pathInfos pruned to paths still reachable from them, and
 // counts of what was skipped. Skipping only warns, never errors, so pushes
 // and the build hook keep succeeding under a server-side size policy.
-func filterOversizedClosures(topLevelPaths []string, pathInfos map[string]*PathInfo, maxNarSize uint64) ([]string, map[string]*PathInfo, skippedUploads) {
+// With noClosure, each path is judged on its own NarSize.
+func filterOversizedClosures(
+	topLevelPaths []string,
+	pathInfos map[string]*PathInfo,
+	maxNarSize uint64,
+	noClosure bool,
+) ([]string, map[string]*PathInfo, skippedUploads) {
 	if maxNarSize == 0 {
 		return topLevelPaths, pathInfos, skippedUploads{}
 	}
 
-	closureMembership := computeClosureMembership(topLevelPaths, pathInfos)
+	closureMembership := computeClosureMembership(topLevelPaths, pathInfos, noClosure)
 	kept := make([]string, 0, len(topLevelPaths))
 
 nextClosure:
@@ -370,21 +393,66 @@ nextClosure:
 	return kept, prunedInfos, skipped
 }
 
+// runConcurrently applies fn to every item, running at most limit at a time,
+// and returns the first error. A limit of 0 or less means unbounded.
+func runConcurrently[T any](ctx context.Context, limit int, items []T, fn func(context.Context, T) error) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	if limit <= 0 || limit > len(items) {
+		limit = len(items)
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+
+	for _, item := range items {
+		g.Go(func() error {
+			return fn(ctx, item)
+		})
+	}
+
+	return g.Wait() //nolint:wrapcheck // errgroup returns the first task's already-wrapped error
+}
+
+// closureCallConcurrency bounds concurrent per-closure server calls.
+// --no-closure closures hold one path each, so their commits never upsert the
+// same object row and can overlap. Ordinary closures overlap heavily and their
+// concurrent upserts can deadlock in Postgres, so they stay sequential.
+func (c *Client) closureCallConcurrency() int {
+	if !c.NoClosure {
+		return 1
+	}
+
+	return c.MaxConcurrentNARUploads
+}
+
 // CreatePendingClosures creates pending closures and returns all pending objects and closure ID to narinfo key mapping.
 func (c *Client) CreatePendingClosures(ctx context.Context, closures []ClosureInfo) (map[string]PendingObject, map[string]string, error) {
 	pendingObjects := make(map[string]PendingObject)
 	closureIDToNarinfoKey := make(map[string]string) // Maps closure ID -> narinfo key
 
-	for _, closure := range closures {
+	var mu sync.Mutex
+
+	err := runConcurrently(ctx, c.closureCallConcurrency(), closures, func(ctx context.Context, closure ClosureInfo) error {
 		resp, err := c.CreatePendingClosure(ctx, closure.NarinfoKey, closure.Objects, c.VerifyS3Integrity)
 		if err != nil {
-			return nil, nil, fmt.Errorf("creating pending closure: %w", err)
+			return fmt.Errorf("creating pending closure: %w", err)
 		}
+
+		mu.Lock()
+		defer mu.Unlock()
 
 		closureIDToNarinfoKey[resp.ID] = closure.NarinfoKey
 
 		// Collect pending objects
 		maps.Copy(pendingObjects, resp.PendingObjects)
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return pendingObjects, closureIDToNarinfoKey, nil
@@ -418,13 +486,25 @@ func (c *Client) SignAndUploadNarinfos(ctx context.Context, narinfosByClosureID 
 	// Sign narinfos for each closure
 	signaturesByKey := make(map[string][]string)
 
-	for closureID, narinfos := range narinfosByClosureID {
-		signatures, err := c.SignPendingClosure(ctx, closureID, narinfos)
+	var mu sync.Mutex
+
+	closureIDs := slices.Collect(maps.Keys(narinfosByClosureID))
+
+	err := runConcurrently(ctx, c.closureCallConcurrency(), closureIDs, func(ctx context.Context, closureID string) error {
+		signatures, err := c.SignPendingClosure(ctx, closureID, narinfosByClosureID[closureID])
 		if err != nil {
 			return fmt.Errorf("signing narinfos for closure %s: %w", closureID, err)
 		}
 
+		mu.Lock()
+		defer mu.Unlock()
+
 		maps.Copy(signaturesByKey, signatures)
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Generate, compress, and upload narinfos in parallel
@@ -504,6 +584,10 @@ func (c *Client) uploadNarinfosInParallel(ctx context.Context, narinfos []narinf
 // It returns the full list of store paths that were part of the uploaded
 // closures (including transitive dependencies), which callers can use to
 // prune queues of dependency paths that no longer need separate uploads.
+//
+// With c.NoClosure, only the given paths are uploaded and each becomes its own
+// gcroot. Narinfos still record full references, so dependencies already in the
+// cache stay reachable, but callers must push every path they want available.
 func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error) {
 	startTime := time.Now()
 
@@ -516,9 +600,15 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 	slog.Debug("Resolved paths", "original", paths, "resolved", resolvedPaths)
 
 	// Get path info for all paths and their closures
-	slog.Debug("Getting path info", "count", len(resolvedPaths))
+	slog.Debug("Getting path info", "count", len(resolvedPaths), "no_closure", c.NoClosure)
 
-	pathInfos, err := GetPathInfoRecursive(ctx, resolvedPaths, c.NixEnv)
+	var pathInfos map[string]*PathInfo
+	if c.NoClosure {
+		pathInfos, err = GetPathInfo(ctx, resolvedPaths, c.NixEnv)
+	} else {
+		pathInfos, err = GetPathInfoRecursive(ctx, resolvedPaths, c.NixEnv)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("getting path info: %w", err)
 	}
@@ -545,7 +635,7 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 
 	var skipped skippedUploads
 
-	resolvedPaths, pathInfos, skipped = filterOversizedClosures(resolvedPaths, pathInfos, maxNarSize)
+	resolvedPaths, pathInfos, skipped = filterOversizedClosures(resolvedPaths, pathInfos, maxNarSize, c.NoClosure)
 	c.ReportSkippedUploads(ctx, skipped.Paths, skipped.NarBytes)
 
 	if len(resolvedPaths) == 0 {
@@ -555,7 +645,7 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 	}
 
 	// Prepare closures - one per top-level path
-	result, err := PrepareClosures(ctx, resolvedPaths, pathInfos, c.NixEnv)
+	result, err := PrepareClosures(ctx, resolvedPaths, pathInfos, c.NixEnv, c.NoClosure)
 	if err != nil {
 		return nil, fmt.Errorf("preparing closures: %w", err)
 	}
@@ -635,10 +725,16 @@ func (c *Client) PushPaths(ctx context.Context, paths []string) ([]string, error
 	}
 
 	// Complete all pending closures (all objects including narinfos are now uploaded)
-	for id := range closureIDToNarinfoKey {
+	completeIDs := slices.Collect(maps.Keys(closureIDToNarinfoKey))
+
+	if err := runConcurrently(ctx, c.closureCallConcurrency(), completeIDs, func(ctx context.Context, id string) error {
 		if err := c.CompletePendingClosure(ctx, id); err != nil {
-			return nil, fmt.Errorf("completing pending closure %s: %w", id, err)
+			return fmt.Errorf("completing pending closure %s: %w", id, err)
 		}
+
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	duration := time.Since(startTime)

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -47,6 +47,11 @@ func printPushHelp() {
 	fmt.Fprintln(os.Stderr, "        Maximum concurrent uploads (default: 30)")
 	fmt.Fprintln(os.Stderr, "  --verify-s3-integrity")
 	fmt.Fprintln(os.Stderr, "        Verify that objects in database actually exist in S3 before skipping upload")
+	fmt.Fprintln(os.Stderr, "  --no-closure")
+	fmt.Fprintln(os.Stderr, "        Upload exactly the given store paths instead of their closures.")
+	fmt.Fprintln(os.Stderr, "        Each path becomes its own garbage collection root. Callers must pass")
+	fmt.Fprintln(os.Stderr, "        every path they want cached, including dependencies; anything left out")
+	fmt.Fprintln(os.Stderr, "        is only usable if some other push already uploaded it.")
 	fmt.Fprintln(os.Stderr, cmdutil.TLSHelp)
 	fmt.Fprintln(os.Stderr, "  --debug")
 	fmt.Fprintln(os.Stderr, "        Enable debug logging (includes HTTP requests/responses)")
@@ -97,6 +102,7 @@ func run() error {
 		maxConcurrent := pushCmd.Int("max-concurrent-uploads", 30, "Maximum concurrent uploads")
 		verifyS3Integrity := pushCmd.Bool("verify-s3-integrity", false, "Verify S3 integrity")
 		pinName := pushCmd.String("pin", "", "Create a named pin for the pushed closure")
+		noClosure := pushCmd.Bool("no-closure", false, "Upload only the given paths, not their closures")
 		tf := cmdutil.AddTLSFlags(pushCmd)
 
 		ts, err := cmdutil.ParseCommand(pushCmd, cf, tf, os.Args[2:], printPushHelp)
@@ -113,7 +119,20 @@ func run() error {
 			return errors.New("--pin requires exactly one store path")
 		}
 
-		return pushCommand(*cf.ServerURL, ts, paths, *maxConcurrent, *verifyS3Integrity, *pinName, *cf.Debug, tf)
+		// A pin protects paths reachable from its root narinfo. Under
+		// --no-closure that is one path, not the closure the user meant.
+		if *pinName != "" && *noClosure {
+			return errors.New("--pin cannot be combined with --no-closure")
+		}
+
+		return pushCommand(*cf.ServerURL, ts, paths, pushOptions{
+			MaxConcurrent:     *maxConcurrent,
+			VerifyS3Integrity: *verifyS3Integrity,
+			NoClosure:         *noClosure,
+			PinName:           *pinName,
+			Debug:             *cf.Debug,
+			TLS:               tf,
+		})
 
 	case "gc":
 		gcCmd := flag.NewFlagSet("gc", flag.ContinueOnError)
@@ -176,27 +195,36 @@ func run() error {
 	}
 }
 
-func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxConcurrent int, verifyS3Integrity bool, pinName string, debug bool, tf cmdutil.TLSFlags) error {
+// pushOptions carries the tunables of the push subcommand.
+type pushOptions struct {
+	MaxConcurrent     int
+	VerifyS3Integrity bool
+	NoClosure         bool
+	PinName           string
+	Debug             bool
+	TLS               cmdutil.TLSFlags
+}
+
+func pushCommand(serverURL string, ts client.TokenSource, paths []string, opts pushOptions) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if maxConcurrent < 1 {
-		maxConcurrent = 1
-	}
+	maxConcurrent := max(opts.MaxConcurrent, 1)
 
-	c, err := cmdutil.NewClient(ctx, serverURL, ts, tf, debug)
+	c, err := cmdutil.NewClient(ctx, serverURL, ts, opts.TLS, opts.Debug)
 	if err != nil {
 		return err //nolint:wrapcheck // cmdutil errors are already user-facing
 	}
 
 	c.MaxConcurrentNARUploads = maxConcurrent
-	c.VerifyS3Integrity = verifyS3Integrity
+	c.VerifyS3Integrity = opts.VerifyS3Integrity
+	c.NoClosure = opts.NoClosure
 
 	if _, err := c.PushPaths(ctx, paths); err != nil {
 		return fmt.Errorf("pushing paths: %w", err)
 	}
 
-	if pinName != "" {
+	if pinName := opts.PinName; pinName != "" {
 		// The server only accepts store paths, but users typically pass a
 		// ./result symlink as produced by nix-build.
 		storePath, err := c.ResolveStorePath(paths[0])

--- a/server/no_closure_test.go
+++ b/server/no_closure_test.go
@@ -1,0 +1,220 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+	"github.com/Mic92/niks3/server"
+	"github.com/Mic92/niks3/server/oidc"
+)
+
+// pushToServerNoClosure pushes exactly the given paths; each becomes its own gcroot.
+func pushToServerNoClosure(ctx context.Context, serverURL, authToken string, paths []string, nixEnv []string) error {
+	c, err := client.NewClient(ctx, serverURL, authToken)
+	if err != nil {
+		return fmt.Errorf("creating client: %w", err)
+	}
+
+	c.MaxConcurrentNARUploads = 16
+	c.NixEnv = nixEnv
+	c.NoClosure = true
+
+	if _, err := c.PushPaths(ctx, paths); err != nil {
+		return fmt.Errorf("pushing paths: %w", err)
+	}
+
+	return nil
+}
+
+// setupGCTestService starts a service with the handlers a push and a GC run need.
+func setupGCTestService(t *testing.T) (*server.Service, string) {
+	t.Helper()
+
+	testService := createTestServiceWithAuth(t, testAuthToken)
+	t.Cleanup(func() { testService.Close() })
+
+	ok(t, testService.InitializeBucket(t.Context()))
+
+	mux := http.NewServeMux()
+	registerTestHandlers(mux, testService)
+	mux.HandleFunc("DELETE /api/closures", testService.RequireScope(oidc.ScopeWrite, testService.CleanupClosuresOlder))
+	mux.HandleFunc("GET /api/gc/status", testService.RequireScope(oidc.ScopeWrite, testService.GCStatusHandler))
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	return testService, ts.URL
+}
+
+// storePathHash returns the 32-character hash prefix of a store path.
+func storePathHash(storePath string) string {
+	return strings.Split(filepath.Base(storePath), "-")[0]
+}
+
+// addFile adds content to the isolated store. The result has no references:
+// Nix only scans for those in build outputs, not in nix-store --add paths.
+func addFile(t *testing.T, nixEnv []string, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	ok(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return nixStoreAdd(t, nixEnv, path)
+}
+
+// buildDependentDerivations builds app and dep, where app's output embeds
+// dep's store path so Nix records a real app -> dep reference.
+func buildDependentDerivations(ctx context.Context, t *testing.T, nixEnv []string) (string, string) {
+	t.Helper()
+
+	nixExpr := filepath.Join(t.TempDir(), "linked.nix")
+	nixContent := `
+	rec {
+		dep = derivation {
+			name = "niks3-dep";
+			system = builtins.currentSystem;
+			builder = "/bin/sh";
+			args = [ "-c" "echo 'dependency payload' > $out" ];
+		};
+		app = derivation {
+			name = "niks3-app";
+			system = builtins.currentSystem;
+			builder = "/bin/sh";
+			args = [ "-c" "echo ${dep} > $out" ];
+		};
+	}
+	`
+
+	ok(t, os.WriteFile(nixExpr, []byte(nixContent), 0o600))
+
+	build := func(attr string) string {
+		cmd := exec.CommandContext(ctx, "nix-build", nixExpr, "-A", attr, "--no-out-link")
+		cmd.Env = nixEnv
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Skipf("Failed to build %s (nix environment not set up): %v\nOutput: %s", attr, err, output)
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+		return lines[len(lines)-1]
+	}
+
+	// Build dep first so app can embed an already-realised path.
+	dep := build("dep")
+	app := build("app")
+
+	t.Logf("Built app=%s dep=%s", app, dep)
+
+	return app, dep
+}
+
+func countRows(ctx context.Context, t *testing.T, service *server.Service, query string, args ...any) int {
+	t.Helper()
+
+	var count int
+
+	ok(t, service.Pool.QueryRow(ctx, query, args...).Scan(&count))
+
+	return count
+}
+
+// TestNoClosurePushCreatesIndependentGCRoots covers why --no-closure exists:
+// build-only deps are unreachable at once unless each path is its own gcroot.
+func TestNoClosurePushCreatesIndependentGCRoots(t *testing.T) {
+	t.Parallel()
+
+	testService, serverURL := setupGCTestService(t)
+
+	ctx := t.Context()
+	nixEnv := setupIsolatedNixStore(t)
+
+	// Neither references the other: an output and a build-time-only dep.
+	output := addFile(t, nixEnv, "output.txt", "build output")
+	buildDep := addFile(t, nixEnv, "build-dep.txt", "build-time only dependency")
+
+	ok(t, pushToServerNoClosure(ctx, serverURL, testAuthToken, []string{output, buildDep}, nixEnv))
+
+	outputKey := storePathHash(output) + ".narinfo"
+	buildDepKey := storePathHash(buildDep) + ".narinfo"
+
+	// Both paths must be roots, not just uploaded objects.
+	if got := countRows(ctx, t, testService, "SELECT COUNT(*) FROM closures"); got != 2 {
+		t.Errorf("closure count = %d, want 2 (one gcroot per pushed path)", got)
+	}
+
+	for _, key := range []string{outputKey, buildDepKey} {
+		if got := countRows(ctx, t, testService, "SELECT COUNT(*) FROM closures WHERE key = $1", key); got != 1 {
+			t.Errorf("no closure row for %s", key)
+		}
+	}
+
+	// Cutoff spares the fresh closures; the build dep must survive on its own gcroot.
+	c, err := client.NewClient(ctx, serverURL, testAuthToken)
+	ok(t, err)
+
+	_, err = c.RunGarbageCollection(ctx, "1h", "1h", true)
+	ok(t, err)
+
+	for _, key := range []string{outputKey, buildDepKey} {
+		got := countRows(ctx, t, testService,
+			"SELECT COUNT(*) FROM objects WHERE key = $1 AND deleted_at IS NULL", key)
+		if got != 1 {
+			t.Errorf("narinfo %s did not survive GC", key)
+		}
+	}
+}
+
+// TestNoClosurePushKeepsReferencedObjectsReachable shows why --no-closure is
+// safe: a dep stays reachable via a dependent's narinfo refs after its own
+// gcroot is gone.
+func TestNoClosurePushKeepsReferencedObjectsReachable(t *testing.T) {
+	t.Parallel()
+
+	testService, serverURL := setupGCTestService(t)
+
+	ctx := t.Context()
+	nixEnv := setupIsolatedNixStore(t)
+
+	app, dep := buildDependentDerivations(ctx, t, nixEnv)
+
+	ok(t, pushToServerNoClosure(ctx, serverURL, testAuthToken, []string{app, dep}, nixEnv))
+
+	appKey := storePathHash(app) + ".narinfo"
+	depKey := storePathHash(dep) + ".narinfo"
+
+	// Guard the fixture: without a real reference this test proves nothing.
+	var refs []string
+
+	ok(t, testService.Pool.QueryRow(ctx, "SELECT refs FROM objects WHERE key = $1", appKey).Scan(&refs))
+
+	if !slices.Contains(refs, depKey) {
+		t.Fatalf("app narinfo refs = %v, want it to contain %s", refs, depKey)
+	}
+
+	// Drop dep's gcroot: its objects are now reachable only via app's refs.
+	_, err := testService.Pool.Exec(ctx, "DELETE FROM closures WHERE key = $1", depKey)
+	ok(t, err)
+
+	c, err := client.NewClient(ctx, serverURL, testAuthToken)
+	ok(t, err)
+
+	_, err = c.RunGarbageCollection(ctx, "1h", "1h", true)
+	ok(t, err)
+
+	got := countRows(ctx, t, testService,
+		"SELECT COUNT(*) FROM objects WHERE key = $1 AND deleted_at IS NULL", depKey)
+	if got != 1 {
+		t.Errorf("dependency narinfo %s was collected despite being referenced by %s", depKey, appKey)
+	}
+}


### PR DESCRIPTION
Allow to just dump a set of nix paths to upload, without having Niks3 compute the closures from them.
This will be used to implement `--niks3-push-build-closure` in [nix-fast-build](https://github.com/Mic92/nix-fast-build).