### PR TITLE
server: add --s3-public-url for presigned URLs

### DIFF
--- a/deploy/helm/niks3/templates/deployment.yaml
+++ b/deploy/helm/niks3/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
               value: /secrets/token/token
             - name: NIKS3_S3_ENDPOINT
               value: {{ required "s3.endpoint is required" .Values.s3.endpoint | quote }}
+            {{- with .Values.s3.publicURL }}
+            - name: NIKS3_S3_PUBLIC_URL
+              value: {{ . | quote }}
+            {{- end }}
             - name: NIKS3_S3_BUCKET
               value: {{ required "s3.bucket is required" .Values.s3.bucket | quote }}
             - name: NIKS3_S3_USE_SSL

--- a/deploy/helm/niks3/values.schema.json
+++ b/deploy/helm/niks3/values.schema.json
@@ -50,6 +50,10 @@
         "endpoint": {
           "type": "string"
         },
+        "publicURL": {
+          "type": "string",
+          "pattern": "^(https?://[^/]+/?)?$"
+        },
         "bucket": {
           "type": "string"
         },
@@ -88,7 +92,8 @@
           "type": "string"
         },
         "token": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(.{36,})?$"
         },
         "workloadIdentity": {
           "type": "object",

--- a/deploy/helm/niks3/values.yaml
+++ b/deploy/helm/niks3/values.yaml
@@ -12,7 +12,12 @@ database:
   # Or inline. The chart creates the Secret.
   url: ""
 s3:
+  # host[:port] the server talks to. Clients upload via presigned URLs, so this
+  # must also be reachable from wherever `niks3 push` runs unless publicURL is set.
   endpoint: ""
+  # Externally reachable http(s)://host[:port] for presigned URLs when
+  # `endpoint` is cluster-internal (e.g. rustfs.rustfs.svc:9000).
+  publicURL: ""
   bucket: ""
   region: ""
   useSSL: true
@@ -24,6 +29,7 @@ s3:
   secretKey: ""
 auth:
   # Shared API token (>= 36 chars) for uploads and GC; Secret key `token`.
+  # Always required (the GC CronJob uses it), also with workloadIdentity.
   existingSecret: ""
   token: ""
   # Allow pods to push with their service account token, see wiki/Kubernetes.

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -170,6 +170,10 @@ let
     "--s3-region"
     cfg.s3.region
   ]
+  ++ lib.optionals (cfg.s3.publicUrl != null) [
+    "--s3-public-url"
+    cfg.s3.publicUrl
+  ]
   ++ (
     if cfg.s3.useIAM then
       [ "--s3-use-iam" ]
@@ -302,6 +306,18 @@ in
         type = lib.types.bool;
         default = true;
         description = "Whether to use SSL for S3 connections.";
+      };
+
+      publicUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "https://s3.example.com";
+        description = ''
+          Externally reachable S3 base URL (http(s)://host[:port]) used in
+          presigned URLs handed to clients. Defaults to the endpoint. Set this
+          when the server reaches S3 via an internal address that clients
+          cannot resolve.
+        '';
       };
 
       bucketLookup = lib.mkOption {

--- a/server/client_integration_test.go
+++ b/server/client_integration_test.go
@@ -607,6 +607,7 @@ func TestPinProtectsFromGC(t *testing.T) {
 	testService := &server.Service{
 		Pool:          service.Pool,
 		MinioClient:   service.MinioClient,
+		PresignClient: service.PresignClient,
 		Bucket:        service.Bucket,
 		APIToken:      testAuthToken,
 		S3RateLimiter: service.S3RateLimiter,

--- a/server/main.go
+++ b/server/main.go
@@ -165,6 +165,9 @@ func parseArgs() (*options, error) {
 		"Path to file containing the Postgres connection string (e.g. a mounted Kubernetes secret)")
 	flag.StringVar(&opts.HTTPAddr, "http-addr", getEnvOrDefault("NIKS3_HTTP_ADDR", ":5751"), "HTTP address to listen on")
 	flag.StringVar(&opts.S3Endpoint, "s3-endpoint", getEnvOrDefault("NIKS3_S3_ENDPOINT", ""), "S3 endpoint")
+	flag.StringVar(&opts.S3PublicURL, "s3-public-url", getEnvOrDefault("NIKS3_S3_PUBLIC_URL", ""),
+		"Externally reachable S3 base URL (http(s)://host[:port]) used in presigned URLs handed to clients; "+
+			"defaults to --s3-endpoint. Set this when the server reaches S3 via an internal address")
 	flag.StringVar(&opts.S3AccessKey, "s3-access-key", getEnvOrDefault("NIKS3_S3_ACCESS_KEY", ""), "S3 access key")
 	flag.StringVar(&opts.S3SecretKey, "s3-secret-key", getEnvOrDefault("NIKS3_S3_SECRET_KEY", ""), "S3 secret key")
 	flag.BoolVar(&opts.S3UseSSL, "s3-use-ssl", getEnvOrDefault("NIKS3_S3_USE_SSL", "true") == "true", "Use SSL for S3")

--- a/server/pending_closure.go
+++ b/server/pending_closure.go
@@ -350,7 +350,7 @@ func (s *Service) makePresignedURL(ctx context.Context, objectKey string, object
 		return PendingObject{}, err
 	}
 
-	presignedURL, err := s.MinioClient.PresignedPutObject(ctx,
+	presignedURL, err := s.PresignClient.PresignedPutObject(ctx,
 		s.Bucket,
 		objectKey,
 		maxSignedURLDuration)

--- a/server/pending_multipart.go
+++ b/server/pending_multipart.go
@@ -148,7 +148,7 @@ func (s *Service) generatePartURLs(ctx context.Context, objectKey, uploadID stri
 		reqParams.Set("uploadId", uploadID)
 		reqParams.Set("partNumber", strconv.Itoa(partNumber))
 
-		presignedURL, err := s.MinioClient.Presign(ctx,
+		presignedURL, err := s.PresignClient.Presign(ctx,
 			"PUT",
 			s.Bucket,
 			objectKey,

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -267,7 +267,7 @@ func (s *Service) ReadProxyHandler(w http.ResponseWriter, r *http.Request) {
 // redirectToS3 sends the client to a presigned URL for key. Presigning is
 // local; a missing object 404s from S3 rather than from here.
 func (s *Service) redirectToS3(w http.ResponseWriter, r *http.Request, key string) {
-	presigned, err := s.MinioClient.PresignedGetObject(r.Context(), s.Bucket, key, s.ReadRedirectTTL, nil)
+	presigned, err := s.PresignClient.PresignedGetObject(r.Context(), s.Bucket, key, s.ReadRedirectTTL, nil)
 	if err != nil {
 		slog.Error("Failed to presign S3 object", "key", key, "error", err)
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)

--- a/server/proxy_test.go
+++ b/server/proxy_test.go
@@ -574,3 +574,59 @@ func TestReadProxyRangeRequest(t *testing.T) {
 		t.Fatalf("unsatisfiable: status = %d, want 416", resp.StatusCode)
 	}
 }
+
+// With a public S3 URL configured, presigned URLs must point at that host
+// rather than the endpoint the server itself talks to.
+func TestReadRedirectUsesPublicS3URL(t *testing.T) {
+	t.Parallel()
+
+	service := createProxyTestService(t)
+	service.ReadRedirectTTL = time.Minute
+
+	defer service.Close()
+
+	ctx := t.Context()
+
+	presign, err := server.NewPresignClient(ctx, service.MinioClient, testRustfsServer.Creds(),
+		"https://s3.public.example", service.Bucket, "", minio.BucketLookupPath)
+	ok(t, err)
+
+	service.PresignClient = presign
+
+	key := "nar/1ngi2dxw1f7khrrjamzkkdai393lwcm8s78gvs1ag8k3n82w7bvp.nar.zst"
+	putTestObject(ctx, t, service, key, []byte("x"), minio.PutObjectOptions{})
+
+	ts := setupProxyServer(t, service)
+	defer ts.Close()
+
+	noFollow := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/"+key, nil)
+	ok(t, err)
+
+	resp, err := noFollow.Do(req)
+	ok(t, err)
+	_ = resp.Body.Close()
+
+	location, err := url.Parse(resp.Header.Get("Location"))
+	ok(t, err)
+
+	if location.Scheme != "https" || location.Host != "s3.public.example" {
+		t.Errorf("Location = %s, want https://s3.public.example/...", location)
+	}
+
+	if location.Query().Get("X-Amz-Signature") == "" {
+		t.Errorf("Location is not presigned: %s", location)
+	}
+
+	for _, bad := range []string{"s3.public.example", "https://s3.public.example/bucket", "ftp://x"} {
+		if _, err := server.NewPresignClient(ctx, service.MinioClient, testRustfsServer.Creds(),
+			bad, service.Bucket, "us-east-1", minio.BucketLookupPath); err == nil {
+			t.Errorf("NewPresignClient(%q) accepted invalid URL", bad)
+		}
+	}
+}

--- a/server/request_test.go
+++ b/server/request_test.go
@@ -63,6 +63,7 @@ func createTestService(tb testing.TB) *server.Service {
 		Pool:          pool,
 		Bucket:        bucketName,
 		MinioClient:   minioClient,
+		PresignClient: minioClient,
 		S3Concurrency: 100,
 		S3RateLimiter: ratelimit.NewAdaptiveRateLimiter(0, "s3-test"), // Start unlimited for tests
 		GCTasks:       server.NewGCTaskStore(),

--- a/server/rustfs_test.go
+++ b/server/rustfs_test.go
@@ -81,12 +81,16 @@ func (s *rustfsServer) ClientWithEndpoint(tb testing.TB, endpoint string) *minio
 
 	// minio-go client works with any S3-compatible storage including RustFS
 	minioClient, err := minio.New(endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4("rustfsadmin", s.secret, ""),
+		Creds:  s.Creds(),
 		Secure: false,
 	})
 	ok(tb, err)
 
 	return minioClient
+}
+
+func (s *rustfsServer) Creds() *credentials.Credentials {
+	return credentials.NewStaticV4("rustfsadmin", s.secret, "")
 }
 
 func terminateProcess(cmd *exec.Cmd) {

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -28,7 +29,11 @@ type options struct {
 	DBConnectionString string
 	HTTPAddr           string
 
-	S3Endpoint     string
+	S3Endpoint string
+	// S3PublicURL, when set, is the externally reachable S3 base URL
+	// (scheme://host[:port]) used for presigned URLs handed to clients,
+	// while S3Endpoint is used for the server's own S3 traffic.
+	S3PublicURL    string
 	S3AccessKey    string
 	S3SecretKey    string
 	S3UseSSL       bool
@@ -94,8 +99,11 @@ type options struct {
 }
 
 type Service struct {
-	Pool                  *pgxpool.Pool
-	MinioClient           *minio.Client
+	Pool        *pgxpool.Pool
+	MinioClient *minio.Client
+	// PresignClient signs URLs handed out to clients. Same as MinioClient
+	// unless a separate public S3 URL is configured.
+	PresignClient         *minio.Client
 	Bucket                string
 	S3Concurrency         int
 	S3RateLimiter         *ratelimit.AdaptiveRateLimiter
@@ -144,6 +152,42 @@ const (
 	shutdownTimeout = 10 * time.Second
 )
 
+// NewPresignClient returns a client for signing client-facing URLs against
+// publicURL (http(s)://host[:port]). Presigning is offline as long as the
+// region is known, so the bucket region is resolved via the internal client
+// up front; the public host need not be reachable from the server.
+func NewPresignClient(
+	ctx context.Context,
+	internal *minio.Client,
+	creds *credentials.Credentials,
+	publicURL, bucket, region string,
+	lookup minio.BucketLookupType,
+) (*minio.Client, error) {
+	u, err := url.Parse(publicURL)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") || (u.Path != "" && u.Path != "/") {
+		return nil, fmt.Errorf("invalid S3 public URL %q: expected http(s)://host[:port]", publicURL)
+	}
+
+	if region == "" {
+		region, err = internal.GetBucketLocation(ctx, bucket)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up bucket region for presigning: %w", err)
+		}
+	}
+
+	client, err := minio.New(u.Host, &minio.Options{
+		Creds:        creds,
+		Secure:       u.Scheme == "https",
+		Region:       region,
+		BucketLookup: lookup,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create presign s3 client: %w", err)
+	}
+
+	return client, nil
+}
+
 func runServer(opts *options) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbConnectionTimeout)
 	defer cancel()
@@ -171,9 +215,19 @@ func runServer(opts *options) error {
 		return fmt.Errorf("failed to create minio s3 client: %w", err)
 	}
 
+	presignClient := minioClient
+	if opts.S3PublicURL != "" {
+		presignClient, err = NewPresignClient(ctx, minioClient, creds,
+			opts.S3PublicURL, opts.S3Bucket, opts.S3Region, opts.S3BucketLookup)
+		if err != nil {
+			return err
+		}
+	}
+
 	service := &Service{
 		Pool:                  pool,
 		MinioClient:           minioClient,
+		PresignClient:         presignClient,
 		Bucket:                opts.S3Bucket,
 		S3Concurrency:         opts.S3Concurrency,
 		S3RateLimiter:         ratelimit.NewAdaptiveRateLimiter(opts.S3RateLimit, "s3"),


### PR DESCRIPTION
Presigned URLs embed the S3 endpoint host, which clients must reach. With a cluster-internal endpoint like minio.minio.svc:9000 pushes from outside fail with 'lookup minio: no such host'.

--s3-public-url sets the host used for presigning only. The bucket region is looked up via the internal client so signing stays offline.

Wired into the Helm chart (s3.publicURL) and NixOS module (s3.publicUrl). The chart schema now also rejects auth.token shorter than 36 chars.