### PR TITLE
oidc: detect Kubernetes issuer from own service account token

### DIFF
--- a/deploy/helm/niks3/templates/_helpers.tpl
+++ b/deploy/helm/niks3/templates/_helpers.tpl
@@ -64,6 +64,7 @@ app.kubernetes.io/component: server
 {{- end }}
 {{- $_ := set $providers "kubernetes" (dict
   "issuer" .issuer
+  "jwks_url" "https://kubernetes.default.svc/openid/v1/jwks"
   "audience" .audience
   "bound_subject" $subjects
   "scopes" .scopes

--- a/deploy/helm/niks3/values.yaml
+++ b/deploy/helm/niks3/values.yaml
@@ -38,7 +38,7 @@ auth:
     allowedServiceAccounts: [] # "<namespace>:<name>", globs allowed
     scopes: [write] # read | write | admin
     audience: niks3
-    issuer: https://kubernetes.default.svc.cluster.local
+    issuer: "" # detected from the pod's service account token
   # Further OIDC providers in the server's JSON schema, keyed by name.
   oidcProviders: {}
 signing:

--- a/deploy/helm/niks3/values.yaml
+++ b/deploy/helm/niks3/values.yaml
@@ -28,7 +28,7 @@ s3:
   accessKey: ""
   secretKey: ""
 auth:
-  # Shared API token (>= 36 chars) for uploads and GC; Secret key `token`.
+  # Shared API token (>= 36 chars) for uploads and GC. Secret key `token`.
   # Always required (the GC CronJob uses it), also with workloadIdentity.
   existingSecret: ""
   token: ""

--- a/nix/nixosModules/niks3.nix
+++ b/nix/nixosModules/niks3.nix
@@ -18,10 +18,12 @@ let
   providerModule = lib.types.submodule {
     options = {
       issuer = lib.mkOption {
-        type = lib.types.str;
+        type = lib.types.nullOr lib.types.str;
+        default = null;
         description = ''
           OIDC issuer URL. Must use HTTPS.
-          Used to construct discovery URL: {issuer}/.well-known/openid-configuration
+          Used to construct discovery URL: {issuer}/.well-known/openid-configuration.
+          May be null when bearerTokenFile is set, the issuer is then read from that token.
         '';
         example = "https://token.actions.githubusercontent.com";
       };
@@ -106,6 +108,13 @@ let
         default = null;
         description = "Bearer token sent when fetching discovery/JWKS, for issuers that require authentication (e.g. a Kubernetes API server).";
       };
+
+      jwksUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "https://kubernetes.default.svc/openid/v1/jwks";
+        description = "Fetch signing keys from this URL instead of running discovery against the issuer.";
+      };
     };
   };
 
@@ -116,8 +125,13 @@ let
         providers = lib.mapAttrs (
           _name: provider:
           {
-            issuer = provider.issuer;
             audience = provider.audience;
+          }
+          // lib.optionalAttrs (provider.issuer != null) {
+            issuer = provider.issuer;
+          }
+          // lib.optionalAttrs (provider.jwksUrl != null) {
+            jwks_url = provider.jwksUrl;
           }
           // (
             if provider.rules != [ ] then

--- a/server/main.go
+++ b/server/main.go
@@ -166,8 +166,8 @@ func parseArgs() (*options, error) {
 	flag.StringVar(&opts.HTTPAddr, "http-addr", getEnvOrDefault("NIKS3_HTTP_ADDR", ":5751"), "HTTP address to listen on")
 	flag.StringVar(&opts.S3Endpoint, "s3-endpoint", getEnvOrDefault("NIKS3_S3_ENDPOINT", ""), "S3 endpoint")
 	flag.StringVar(&opts.S3PublicURL, "s3-public-url", getEnvOrDefault("NIKS3_S3_PUBLIC_URL", ""),
-		"Externally reachable S3 base URL (http(s)://host[:port]) used in presigned URLs handed to clients; "+
-			"defaults to --s3-endpoint. Set this when the server reaches S3 via an internal address")
+		"Externally reachable S3 base URL (http(s)://host[:port]) used in presigned URLs handed to clients. "+
+			"Defaults to --s3-endpoint. Set this when the server reaches S3 via an internal address")
 	flag.StringVar(&opts.S3AccessKey, "s3-access-key", getEnvOrDefault("NIKS3_S3_ACCESS_KEY", ""), "S3 access key")
 	flag.StringVar(&opts.S3SecretKey, "s3-secret-key", getEnvOrDefault("NIKS3_S3_SECRET_KEY", ""), "S3 secret key")
 	flag.BoolVar(&opts.S3UseSSL, "s3-use-ssl", getEnvOrDefault("NIKS3_S3_USE_SSL", "true") == "true", "Use SSL for S3")
@@ -186,8 +186,8 @@ func parseArgs() (*options, error) {
 	flag.StringVar(&opts.CacheURL, "cache-url", getEnvOrDefault("NIKS3_CACHE_URL", ""),
 		"Public cache URL for the landing page (e.g., https://cache.example.com)")
 	flag.StringVar(&opts.ServerURL, "server-url", getEnvOrDefault("NIKS3_SERVER_URL", ""),
-		"Public niks3 server URL the landing page fetches cache stats from (e.g., https://niks3.example.com); "+
-			"defaults to a same-origin relative path")
+		"Public niks3 server URL the landing page fetches cache stats from (e.g., https://niks3.example.com). "+
+			"Defaults to a same-origin relative path")
 	flag.StringVar(&opts.OIDCConfigPath, "oidc-config", getEnvOrDefault("NIKS3_OIDC_CONFIG", ""),
 		"Path to OIDC configuration file (JSON format)")
 	flag.IntVar(&opts.S3Concurrency, "s3-concurrency", getEnvOrDefaultInt("NIKS3_S3_CONCURRENCY", defaultS3Concurrency),
@@ -195,30 +195,30 @@ func parseArgs() (*options, error) {
 	flag.Float64Var(&opts.S3RateLimit, "s3-rate-limit", getEnvOrDefaultFloat("NIKS3_S3_RATE_LIMIT", 0),
 		"Initial S3 requests per second (0 = unlimited, adapts on 429)")
 	flag.StringVar(&opts.MTLSProxyHeader, "mtls-proxy-header", getEnvOrDefault("NIKS3_MTLS_PROXY_HEADER", ""),
-		"Header set to SUCCESS by the reverse proxy after mTLS client cert verification (e.g. X-SSL-Client-Verify); requests with it skip bearer auth")
+		"Header set to SUCCESS by the reverse proxy after mTLS client cert verification (e.g. X-SSL-Client-Verify). Requests with it skip bearer auth")
 	flag.StringVar(&opts.MTLSSubjectHeader, "mtls-subject-header", getEnvOrDefault("NIKS3_MTLS_SUBJECT_HEADER", "X-SSL-Client-Dn"),
 		"Header carrying the verified cert's subject DN, used with --mtls-bound-subject")
 
 	flag.Var((*stringSliceFlag)(&opts.MTLSBoundSubjects), "mtls-bound-subject",
-		"Restrict mTLS write auth to certs whose subject DN matches this glob; repeat for multiple patterns")
+		"Restrict mTLS write auth to certs whose subject DN matches this glob. Repeat for multiple patterns")
 	flag.Var((*stringSliceFlag)(&opts.MTLSBoundSubjectsRead), "mtls-bound-subject-read",
-		"Gate the read proxy behind mTLS for certs whose subject DN matches this glob; repeat for multiple patterns. Empty = public reads")
+		"Gate the read proxy behind mTLS for certs whose subject DN matches this glob. Repeat for multiple patterns. Empty = public reads")
 	flag.StringVar(&opts.TLSCert, "tls-cert", getEnvOrDefault("NIKS3_TLS_CERT", ""),
-		"TLS certificate; when set with --tls-key the server terminates TLS itself instead of expecting a reverse proxy")
+		"TLS certificate. When set with --tls-key the server terminates TLS itself instead of expecting a reverse proxy")
 	flag.StringVar(&opts.TLSKey, "tls-key", getEnvOrDefault("NIKS3_TLS_KEY", ""), "TLS private key")
 	flag.StringVar(&opts.TLSClientCA, "tls-client-ca", getEnvOrDefault("NIKS3_TLS_CLIENT_CA", ""),
-		"CA bundle for native mTLS client cert verification; subjects checked against --mtls-bound-subject")
+		"CA bundle for native mTLS client cert verification. Subjects are checked against --mtls-bound-subject")
 	flag.StringVar(&maxNarSize, "max-nar-size", getEnvOrDefault("NIKS3_MAX_NAR_SIZE", ""),
 		"Maximum uncompressed NAR size accepted for upload (e.g. 2G, 512M). Empty or 0 means unlimited")
 	flag.IntVar(&opts.CachePriority, "cache-priority", getEnvOrDefaultInt("NIKS3_CACHE_PRIORITY", defaultCachePriority),
-		"Priority advertised in nix-cache-info; lower is preferred (cache.nixos.org uses 40)")
+		"Priority advertised in nix-cache-info. Lower is preferred (cache.nixos.org uses 40)")
 	flag.BoolVar(&opts.EnableReadProxy, "enable-read-proxy",
 		getEnvOrDefault("NIKS3_ENABLE_READ_PROXY", "false") == "true",
 		"Serve cache objects by proxying reads from S3 (for private buckets)")
 	flag.DurationVar(&opts.ReadRedirectTTL, "read-redirect-ttl",
 		getEnvOrDefaultDuration("NIKS3_READ_REDIRECT_TTL", 0),
 		"Answer NAR reads with a redirect to a presigned S3 URL valid for this long (e.g. 15m) instead of "+
-			"streaming them; requires --enable-read-proxy. 0 disables")
+			"streaming them. Requires --enable-read-proxy. 0 disables")
 	flag.BoolVar(&opts.Debug, "debug", getEnvOrDefault("NIKS3_DEBUG", "false") == "true",
 		"Enable debug logging (may leak sensitive information)")
 

--- a/server/oidc/config.go
+++ b/server/oidc/config.go
@@ -2,11 +2,13 @@
 package oidc
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 )
 
 // Config holds the OIDC configuration with multiple providers.
@@ -43,10 +45,12 @@ type Rule struct {
 
 // ProviderConfig configures a single OIDC provider.
 type ProviderConfig struct {
-	// Issuer is the OIDC issuer URL (required).
-	// Used to construct discovery URL: {issuer}/.well-known/openid-configuration
-	// Example: "https://token.actions.githubusercontent.com"
+	// Issuer is the OIDC issuer URL, e.g. "https://token.actions.githubusercontent.com".
+	// Empty means: take the iss claim of BearerTokenFile (Kubernetes).
 	Issuer string `json:"issuer"`
+
+	// JWKSURL skips discovery and fetches signing keys from here.
+	JWKSURL string `json:"jwks_url,omitempty"`
 
 	// Audience is the expected audience claim (required).
 	// Should be your service URL or a unique identifier.
@@ -144,6 +148,19 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
+	for name, provider := range cfg.Providers {
+		if provider.Issuer != "" || provider.BearerTokenFile == "" {
+			continue
+		}
+
+		iss, err := issuerFromTokenFile(provider.BearerTokenFile)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: detecting issuer from bearer_token_file: %w", name, err)
+		}
+
+		provider.Issuer = iss
+	}
+
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
 	}
@@ -165,7 +182,13 @@ func (c *Config) validate() error {
 
 	for name, provider := range c.Providers {
 		if provider.Issuer == "" {
-			return fmt.Errorf("provider %q: missing issuer", name)
+			return fmt.Errorf("provider %q: missing issuer (or bearer_token_file to detect it from)", name)
+		}
+
+		if provider.JWKSURL != "" {
+			if u, err := url.Parse(provider.JWKSURL); err != nil || u.Scheme != "https" && !c.AllowInsecure || u.Host == "" {
+				return fmt.Errorf("provider %q: jwks_url %q must be an absolute HTTPS URL", name, provider.JWKSURL)
+			}
 		}
 
 		// Validate issuer URL format and require HTTPS (unless AllowInsecure)
@@ -200,4 +223,34 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+func issuerFromTokenFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading token: %w", err)
+	}
+
+	parts := strings.Split(strings.TrimSpace(string(data)), ".")
+	if len(parts) != 3 { //nolint:mnd // header.payload.signature
+		return "", errors.New("not a JWT")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decoding JWT payload: %w", err)
+	}
+
+	var claims struct {
+		Iss string `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parsing JWT payload: %w", err)
+	}
+
+	if claims.Iss == "" {
+		return "", errors.New("token has no iss claim")
+	}
+
+	return claims.Iss, nil
 }

--- a/server/oidc/kubernetes_test.go
+++ b/server/oidc/kubernetes_test.go
@@ -145,3 +145,76 @@ func TestNewValidator_KubernetesRequiresCA(t *testing.T) {
 		t.Fatal("expected discovery against private CA without ca_file to fail")
 	}
 }
+
+// Managed clusters (EKS/GKE/AKS) use an issuer that is not the API server.
+// With issuer left empty and jwks_url pointing at the API server, niks3
+// learns the issuer from its own service account token and never contacts
+// the issuer host.
+func TestValidateToken_KubernetesIssuerFromOwnToken(t *testing.T) {
+	t.Parallel()
+
+	kp, err := mockoidc.NewKeypair(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const issuer = "https://oidc.eks.invalid/id/ABC123"
+
+	dir := t.TempDir()
+
+	ownToken, err := kp.SignJWT(jwt.MapClaims{
+		"iss": issuer,
+		"aud": []string{"https://kubernetes.default.svc"},
+		"sub": "system:serviceaccount:niks3:niks3",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := kubeAPIServer(t, kp, ownToken)
+
+	caFile := filepath.Join(dir, "ca.crt")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+
+	if err := os.WriteFile(caFile, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tokenFile := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenFile, []byte(ownToken+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config := oidc.Config{
+		Providers: map[string]*oidc.ProviderConfig{
+			"kubernetes": {
+				Audience:        "niks3",
+				BoundSubject:    []string{"system:serviceaccount:ci:*"},
+				CAFile:          caFile,
+				BearerTokenFile: tokenFile,
+				JWKSURL:         srv.URL + "/openid/v1/jwks",
+			},
+		},
+	}
+	ctx, validator := oidctest.NewValidator(t, config)
+
+	tok, err := kp.SignJWT(jwt.MapClaims{
+		"iss": issuer,
+		"aud": []string{"niks3"},
+		"sub": "system:serviceaccount:ci:builder",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := validator.ValidateToken(ctx, tok); err != nil {
+		t.Fatalf("expected token with auto-detected issuer to validate: %v", err)
+	}
+
+	if got, ok := validator.AudienceForIssuer(issuer); !ok || got != "niks3" {
+		t.Errorf("AudienceForIssuer(%q) = %q, %v", issuer, got, ok)
+	}
+}

--- a/server/oidc/validator.go
+++ b/server/oidc/validator.go
@@ -122,6 +122,15 @@ func httpClientFor(p *ProviderConfig) (*http.Client, error) {
 	return &http.Client{Transport: rt}, nil
 }
 
+// asymmetricAlgs is accepted when discovery is skipped. The JWKS key type
+// still pins the actual algorithm.
+var asymmetricAlgs = []string{ //nolint:gochecknoglobals
+	gooidc.RS256, gooidc.RS384, gooidc.RS512,
+	gooidc.ES256, gooidc.ES384, gooidc.ES512,
+	gooidc.PS256, gooidc.PS384, gooidc.PS512,
+	gooidc.EdDSA,
+}
+
 // NewValidator creates a new OIDC validator from config.
 func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 	v := &Validator{
@@ -139,8 +148,16 @@ func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 		}
 
 		// go-oidc reuses this context's client for later JWKS fetches.
-		provider, err := gooidc.NewProvider(gooidc.ClientContext(ctx, client), providerCfg.Issuer)
-		if err != nil {
+		clientCtx := gooidc.ClientContext(ctx, client)
+
+		var provider *gooidc.Provider
+		if providerCfg.JWKSURL != "" {
+			provider = (&gooidc.ProviderConfig{
+				IssuerURL:  providerCfg.Issuer,
+				JWKSURL:    providerCfg.JWKSURL,
+				Algorithms: asymmetricAlgs,
+			}).NewProvider(clientCtx)
+		} else if provider, err = gooidc.NewProvider(clientCtx, providerCfg.Issuer); err != nil {
 			return nil, fmt.Errorf("failed to initialize OIDC provider for %s: %w", providerCfg.Issuer, err)
 		}
 
@@ -155,7 +172,7 @@ func NewValidator(ctx context.Context, cfg *Config) (*Validator, error) {
 			config:   providerCfg,
 		}
 
-		slog.Info("OIDC provider initialized", "name", name)
+		slog.Info("OIDC provider initialized", "name", name, "issuer", providerCfg.Issuer)
 	}
 
 	return v, nil

--- a/server/server.go
+++ b/server/server.go
@@ -60,7 +60,7 @@ type options struct {
 	// upload. 0 means unlimited.
 	MaxNarSize uint64
 
-	// CachePriority is advertised in nix-cache-info; lower wins.
+	// CachePriority is advertised in nix-cache-info. Lower wins.
 	CachePriority int
 
 	// MTLSProxyHeader, when set, names a header the reverse proxy sets to
@@ -155,7 +155,7 @@ const (
 // NewPresignClient returns a client for signing client-facing URLs against
 // publicURL (http(s)://host[:port]). Presigning is offline as long as the
 // region is known, so the bucket region is resolved via the internal client
-// up front; the public host need not be reachable from the server.
+// up front, so the public host need not be reachable from the server.
 func NewPresignClient(
 	ctx context.Context,
 	internal *minio.Client,


### PR DESCRIPTION
The chart's default issuer only matched kubeadm clusters. EKS, GKE and AKS use other issuers, so CI tokens failed until set by hand.

With issuer empty and bearer_token_file set, read the issuer from that token's iss claim. The niks3 pod's token comes from the same API server as the CI pods' tokens.

jwks_url skips discovery. The chart uses
https://kubernetes.default.svc/openid/v1/jwks so neither the issuer host nor the node IP in the advertised jwks_uri must be reachable.