### PR TITLE
ci: enable GHCR cleanup for real

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -76,4 +76,3 @@ jobs:
           # regctl pushes children before the index; don't race an in-flight push.
           older-than: 1 day
           validate: true
-          dry-run: true


### PR DESCRIPTION
Dry run confirmed all v*/main/latest digests are excluded and only sha-*
tags and stale untagged indexes are targeted.
