### PR TITLE
niks3-hook: fix socket path ldflags override target

### DIFF
--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -16,11 +16,6 @@ import (
 	"github.com/Mic92/niks3/hook"
 )
 
-// socketPath can be overridden at build time via ldflags:
-//
-//	-ldflags "-X main.socketPath=/custom/path"
-var socketPath = hook.DefaultSocketPath //nolint:gochecknoglobals // ldflags override
-
 func main() {
 	if err := run(); err != nil {
 		slog.Error("Fatal error", "error", err)
@@ -41,7 +36,7 @@ func printSendHelp() {
 	fmt.Fprintln(os.Stderr, "\nSend store paths from OUT_PATHS to the upload daemon via unix socket.")
 	fmt.Fprintln(os.Stderr, "Always exits 0 to avoid affecting Nix builds. Errors are logged to stderr.")
 	fmt.Fprintln(os.Stderr, "\nFlags:")
-	fmt.Fprintf(os.Stderr, "  --socket string\n        Unix socket path (default: %s)\n", socketPath)
+	fmt.Fprintf(os.Stderr, "  --socket string\n        Unix socket path (default: %s)\n", hook.DefaultSocketPath)
 	fmt.Fprintln(os.Stderr, "  -h, --help")
 	fmt.Fprintln(os.Stderr, "        Show this help message")
 }
@@ -103,7 +98,7 @@ func runSend() error {
 	fs := flag.NewFlagSet("send", flag.ContinueOnError)
 	fs.Usage = func() {}
 
-	socket := fs.String("socket", socketPath, "Unix socket path")
+	socket := fs.String("socket", hook.DefaultSocketPath, "Unix socket path")
 	help := fs.Bool("help", false, "Show help")
 	fs.BoolVar(help, "h", false, "Show help")
 

--- a/nix/packages/niks3-hook.nix
+++ b/nix/packages/niks3-hook.nix
@@ -28,7 +28,7 @@ pkgs.buildGoModule {
 
   ldflags = [
     "-X"
-    "main.socketPath=${postBuildHookSocketPath}"
+    "github.com/Mic92/niks3/hook.DefaultSocketPath=${postBuildHookSocketPath}"
   ];
 
   subPackages = [ "cmd/niks3-hook" ];


### PR DESCRIPTION
[Description was LLM generated, reread and validated by me]

The `-X` ldflags target in `nix/packages/niks3-hook.nix` still pointed at
`main.socketPath` after 6eb894a moved the default into
`hook.DefaultSocketPath`. Go's `-X` only overrides variables initialized to a
string constant, and `main.socketPath` was initialized to another variable, so
the override was silently dropped — `postBuildHookSocketPath` had no effect and
the binary always kept `/run/niks3/upload-to-cache.sock`.

This went unnoticed because the NixOS module's `socketPath` default is exactly
that same path, so the broken bake-in happened to produce the correct result.

On Darwin it breaks outright: the module defaults `socketPath` to
`/var/lib/niks3-hook/upload-to-cache.sock`, and since 91eb045 the wrapper relies
entirely on the bake-in instead of passing `--socket`. Every build failed with:

    post-build-hook: niks3-hook send: connecting to socket /run/niks3/upload-to-cache.sock: no such file or directory

Target `hook.DefaultSocketPath` instead, as its own doc comment in
`hook/server.go` already documents, and drop the now-redundant
`main.socketPath` alias.

### Impact

- NixOS with default `socketPath`: no change (same string either way).
- NixOS with custom `socketPath`: fixes the same latent bug.
- `serve` is unaffected — both modules pass `--socket` explicitly.
- `nixos-test-niks3` still asserts `/run/niks3/upload-to-cache.sock` and passes.

### Verification

Standalone two-package Go repro confirming the mechanism:

    -X main.socketPath=...           -> /run/niks3/upload-to-cache.sock   (dropped)
    -X <pkg>.DefaultSocketPath=...   -> /custom/path                      (applied)

Built `niks3-hook` with `postBuildHookSocketPath = "/var/lib/niks3-hook/upload-to-cache.sock"`;
`send --help` now reports that path. Confirmed end-to-end on aarch64-darwin — a
test derivation build now reaches the daemon and uploads successfully.