### PR TITLE
hook: synchronous Wait requests

### DIFF
--- a/cmd/niks3-hook/main.go
+++ b/cmd/niks3-hook/main.go
@@ -248,7 +248,7 @@ func runServe() error {
 	}()
 
 	// Start the socket server.
-	srv := hook.NewServer(ln, queueFunc)
+	srv := hook.NewServer(ln, queueFunc, c.PushPaths)
 
 	// Idle exit: cancel the context when both the socket is idle and the queue is empty.
 	if idleTimeout > 0 {

--- a/hook/client.go
+++ b/hook/client.go
@@ -15,7 +15,13 @@ const sendTimeout = 5 * time.Second
 // any error. The caller should always exit 0 regardless of the error to avoid
 // affecting Nix builds.
 func SendPaths(socketPath string, paths []string) error {
-	if len(paths) == 0 {
+	return Send(socketPath, Request{Paths: paths})
+}
+
+// Send is SendPaths for arbitrary requests. Wait requests have no deadline:
+// an upload takes as long as it takes.
+func Send(socketPath string, req Request) error {
+	if len(req.Paths) == 0 {
 		return nil
 	}
 
@@ -31,13 +37,12 @@ func SendPaths(socketPath string, paths []string) error {
 
 	defer func() { _ = conn.Close() }()
 
-	// Set a deadline for the entire send+receive operation.
-	if err := conn.SetDeadline(time.Now().Add(sendTimeout)); err != nil {
-		return fmt.Errorf("setting deadline: %w", err)
+	if !req.Wait {
+		if err := conn.SetDeadline(time.Now().Add(sendTimeout)); err != nil {
+			return fmt.Errorf("setting deadline: %w", err)
+		}
 	}
 
-	// Send the request.
-	req := Request{Paths: paths}
 	if err := json.NewEncoder(conn).Encode(req); err != nil {
 		return fmt.Errorf("sending request: %w", err)
 	}
@@ -48,7 +53,7 @@ func SendPaths(socketPath string, paths []string) error {
 		return fmt.Errorf("reading response: %w", err)
 	}
 
-	if resp.Status != "ok" {
+	if resp.Status != statusOK {
 		return fmt.Errorf("server error: %s", resp.Message)
 	}
 

--- a/hook/protocol.go
+++ b/hook/protocol.go
@@ -5,6 +5,8 @@ package hook
 // One JSON object per line over a unix stream connection.
 type Request struct {
 	Paths []string `json:"paths"`
+	// Wait pushes synchronously, bypassing the queue, and reports the result.
+	Wait bool `json:"wait,omitempty"`
 }
 
 // Response is sent from the server back to the hook client.

--- a/hook/server.go
+++ b/hook/server.go
@@ -18,23 +18,26 @@ import (
 //	-ldflags "-X github.com/Mic92/niks3/hook.DefaultSocketPath=/custom/path"
 var DefaultSocketPath = "/run/niks3/upload-to-cache.sock" //nolint:gochecknoglobals // ldflags override
 
+const (
+	statusOK    = "ok"
+	statusError = "error"
+)
+
+var errInvalidRequest = errors.New("invalid request")
+
 // QueueFunc is called by the server to persist paths. It must return nil on success.
 type QueueFunc func(paths []string) error
 
 // Server listens on a unix stream socket and accepts path submissions.
 type Server struct {
-	listener  net.Listener
-	queueFunc QueueFunc
-	wg        sync.WaitGroup
+	listener net.Listener
+	queue    QueueFunc
+	push     PushFunc // for Wait requests
+	wg       sync.WaitGroup
 }
 
-// NewServer creates a Server that accepts connections on listener and calls
-// queueFunc for each batch of paths received.
-func NewServer(listener net.Listener, queueFunc QueueFunc) *Server {
-	return &Server{
-		listener:  listener,
-		queueFunc: queueFunc,
-	}
+func NewServer(listener net.Listener, queue QueueFunc, push PushFunc) *Server {
+	return &Server{listener: listener, queue: queue, push: push}
 }
 
 // Serve accepts connections until ctx is cancelled. It blocks until all
@@ -63,7 +66,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 
 		s.wg.Go(func() {
-			s.handleConn(conn)
+			s.handleConn(ctx, conn)
 		})
 	}
 
@@ -72,32 +75,32 @@ func (s *Server) Serve(ctx context.Context) error {
 	return lastErr
 }
 
-func (s *Server) handleConn(conn net.Conn) {
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 
-	var req Request
-	if err := json.NewDecoder(conn).Decode(&req); err != nil {
-		slog.Error("Failed to decode request", "error", err)
-		writeResponse(conn, Response{Status: "error", Message: "invalid request"})
+	var (
+		req Request
+		err error
+	)
+
+	switch {
+	case json.NewDecoder(conn).Decode(&req) != nil:
+		err = errInvalidRequest
+	case len(req.Paths) == 0:
+	case req.Wait:
+		_, err = s.push(ctx, req.Paths)
+	default:
+		err = s.queue(req.Paths)
+	}
+
+	if err != nil {
+		slog.Error("Hook request failed", "error", err, "wait", req.Wait, "count", len(req.Paths))
+		writeResponse(conn, Response{Status: statusError, Message: err.Error()})
 
 		return
 	}
 
-	if len(req.Paths) == 0 {
-		writeResponse(conn, Response{Status: "ok"})
-
-		return
-	}
-
-	if err := s.queueFunc(req.Paths); err != nil {
-		slog.Error("Failed to queue paths", "error", err, "count", len(req.Paths))
-		writeResponse(conn, Response{Status: "error", Message: err.Error()})
-
-		return
-	}
-
-	slog.Debug("Queued paths", "count", len(req.Paths))
-	writeResponse(conn, Response{Status: "ok"})
+	writeResponse(conn, Response{Status: statusOK})
 }
 
 func writeResponse(conn net.Conn, resp Response) {

--- a/hook/server_test.go
+++ b/hook/server_test.go
@@ -2,12 +2,15 @@ package hook_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -42,7 +45,7 @@ func TestServerClientIntegration(t *testing.T) {
 		return nil
 	}
 
-	srv := hook.NewServer(ln, queueFunc)
+	srv := hook.NewServer(ln, queueFunc, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -112,7 +115,7 @@ func TestServerQueueError(t *testing.T) {
 
 	srv := hook.NewServer(ln, func(_ []string) error {
 		return os.ErrPermission
-	})
+	}, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -208,4 +211,50 @@ func TestGetListenerSocketActivation(t *testing.T) { //nolint:paralleltest // t.
 	}
 
 	t.Log(string(output))
+}
+
+func TestServerWait(t *testing.T) {
+	t.Parallel()
+
+	socketPath := filepath.Join(t.TempDir(), "test.sock")
+
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var queued, pushed []string
+
+	pushErr := errors.New("409 stale claim")
+	srv := hook.NewServer(ln, func(paths []string) error {
+		queued = append(queued, paths...)
+
+		return nil
+	}, func(_ context.Context, paths []string) ([]string, error) {
+		pushed = append(pushed, paths...)
+		if paths[0] == "/nix/store/bad" {
+			return nil, pushErr
+		}
+
+		return paths, nil
+	})
+
+	go func() { _ = srv.Serve(t.Context()) }()
+
+	if err := hook.Send(socketPath, hook.Request{Paths: []string{"/nix/store/good"}, Wait: true}); err != nil {
+		t.Fatalf("wait push: %v", err)
+	}
+
+	err = hook.Send(socketPath, hook.Request{Paths: []string{"/nix/store/bad"}, Wait: true})
+	if err == nil || !strings.Contains(err.Error(), pushErr.Error()) {
+		t.Fatalf("want push error propagated, got %v", err)
+	}
+
+	if len(queued) != 0 {
+		t.Fatalf("wait requests must bypass the queue, queued=%v", queued)
+	}
+
+	if !slices.Equal(pushed, []string{"/nix/store/good", "/nix/store/bad"}) {
+		t.Fatalf("pushed = %v", pushed)
+	}
 }


### PR DESCRIPTION
Lets a caller block until the listed paths are committed, optionally fenced by a build claim token.