### PR TITLE
niks3 push: add --stdin streaming mode

### DIFF
--- a/client/streampush.go
+++ b/client/streampush.go
@@ -1,0 +1,183 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+)
+
+const (
+	DefaultStreamBatchSize = 50
+	// Each push has its own NAR upload pool; a few in parallel keep
+	// closure setup of the next batch off the critical path.
+	DefaultStreamParallel = 4
+	// Single-path retries of a failed batch before the server is blamed.
+	streamIsolationProbes = 3
+
+	streamStatusOK    = "ok"
+	streamStatusError = "error"
+)
+
+type StreamPushFunc func(ctx context.Context, paths []string) ([]string, error)
+
+type StreamResult struct {
+	Path    string `json:"path"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+// StreamPusher pushes store paths read line by line from a reader as they
+// arrive and writes one JSON StreamResult per input path, so a long-running
+// CI driver learns per path when it is cached. While all `parallel` pushes
+// are busy, incoming paths accumulate into one batch of up to `batchSize`.
+type StreamPusher struct {
+	push      StreamPushFunc
+	parallel  int
+	batchSize int
+}
+
+func NewStreamPusher(push StreamPushFunc, parallel, batchSize int) *StreamPusher {
+	if parallel < 1 {
+		parallel = 1
+	}
+
+	if batchSize < 1 {
+		batchSize = DefaultStreamBatchSize
+	}
+
+	return &StreamPusher{push: push, parallel: parallel, batchSize: batchSize}
+}
+
+// Run returns after EOF on `in` once every path was reported on `out`.
+func (s *StreamPusher) Run(ctx context.Context, in io.Reader, out io.Writer) error {
+	lines := make(chan string, s.batchSize*s.parallel)
+	readErr := make(chan error, 1)
+
+	go func() {
+		defer close(lines)
+
+		sc := bufio.NewScanner(in)
+		for sc.Scan() {
+			if p := strings.TrimSpace(sc.Text()); p != "" {
+				lines <- p
+			}
+		}
+
+		readErr <- sc.Err()
+	}()
+
+	var (
+		outMu sync.Mutex
+		wg    sync.WaitGroup
+	)
+
+	enc := json.NewEncoder(out)
+	report := func(results []StreamResult) {
+		outMu.Lock()
+		defer outMu.Unlock()
+
+		for _, r := range results {
+			if err := enc.Encode(r); err != nil {
+				slog.Error("Failed to write result", "error", err)
+			}
+		}
+	}
+
+	slots := make(chan struct{}, s.parallel)
+
+	for {
+		first, ok := <-lines
+		if !ok {
+			break
+		}
+
+		batch := append(make([]string, 0, s.batchSize), first)
+
+		slots <- struct{}{}
+
+	fill:
+		for len(batch) < s.batchSize {
+			select {
+			case p, ok := <-lines:
+				if !ok {
+					break fill
+				}
+
+				batch = append(batch, p)
+			default:
+				break fill
+			}
+		}
+
+		wg.Go(func() {
+			defer func() { <-slots }()
+
+			report(s.upload(ctx, batch))
+		})
+	}
+
+	wg.Wait()
+
+	if err := <-readErr; err != nil {
+		return fmt.Errorf("reading paths: %w", err)
+	}
+
+	return nil
+}
+
+// A failed batch is retried path by path so one bad path only costs itself.
+func (s *StreamPusher) upload(ctx context.Context, batch []string) []StreamResult {
+	results := make([]StreamResult, 0, len(batch))
+
+	_, err := s.push(ctx, batch)
+	if err == nil {
+		for _, p := range batch {
+			results = append(results, StreamResult{Path: p, Status: streamStatusOK})
+		}
+
+		return results
+	}
+
+	slog.Error("Upload failed", "error", err, "count", len(batch))
+
+	fail := func(paths []string, err error) {
+		for _, p := range paths {
+			results = append(results, StreamResult{Path: p, Status: streamStatusError, Message: err.Error()})
+		}
+	}
+
+	if len(batch) == 1 || ctx.Err() != nil {
+		fail(batch, err)
+
+		return results
+	}
+
+	succeeded, failures := 0, 0
+
+	for i, p := range batch {
+		if succeeded == 0 && failures >= streamIsolationProbes {
+			slog.Error("Server seems unavailable, giving up on batch", "untried", len(batch)-i)
+			fail(batch[i:], err)
+
+			break
+		}
+
+		if _, perr := s.push(ctx, []string{p}); perr != nil {
+			fail([]string{p}, perr)
+
+			failures++
+
+			continue
+		}
+
+		results = append(results, StreamResult{Path: p, Status: streamStatusOK})
+		succeeded++
+	}
+
+	return results
+}

--- a/client/streampush_test.go
+++ b/client/streampush_test.go
@@ -1,0 +1,230 @@
+package client_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/client"
+)
+
+type result struct {
+	Path    string `json:"path"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func runStream(t *testing.T, push client.StreamPushFunc, parallel, batch int, feed func(w io.Writer)) []result {
+	t.Helper()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	s := client.NewStreamPusher(push, parallel, batch)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- s.Run(context.Background(), inR, outW)
+
+		_ = outW.Close()
+	}()
+
+	go func() {
+		feed(inW)
+
+		_ = inW.Close()
+	}()
+
+	var results []result
+
+	sc := bufio.NewScanner(outR)
+	for sc.Scan() {
+		var r result
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("bad output line %q: %v", sc.Text(), err)
+		}
+
+		results = append(results, r)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after stdin EOF")
+	}
+
+	return results
+}
+
+func TestStreamPushReportsEveryPath(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu     sync.Mutex
+		pushed []string
+	)
+
+	push := func(_ context.Context, paths []string) ([]string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		pushed = append(pushed, paths...)
+
+		return paths, nil
+	}
+
+	results := runStream(t, push, 4, 10, func(w io.Writer) {
+		_, _ = io.WriteString(w, "/nix/store/a\n\n/nix/store/b\n/nix/store/c\n")
+	})
+
+	got := make([]string, 0, len(results))
+
+	for _, r := range results {
+		if r.Status != "ok" {
+			t.Errorf("path %s: status %s (%s)", r.Path, r.Status, r.Message)
+		}
+
+		got = append(got, r.Path)
+	}
+
+	slices.Sort(got)
+	slices.Sort(pushed)
+
+	want := []string{"/nix/store/a", "/nix/store/b", "/nix/store/c"}
+	if !slices.Equal(got, want) {
+		t.Errorf("results = %v, want %v", got, want)
+	}
+
+	if !slices.Equal(pushed, want) {
+		t.Errorf("pushed = %v, want %v", pushed, want)
+	}
+}
+
+func TestStreamPushBatchesUnderLoad(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+
+	var (
+		mu      sync.Mutex
+		batches [][]string
+	)
+
+	push := func(_ context.Context, paths []string) ([]string, error) {
+		mu.Lock()
+
+		batches = append(batches, slices.Clone(paths))
+		first := len(batches) == 1
+
+		mu.Unlock()
+
+		if first {
+			<-release
+		}
+
+		return paths, nil
+	}
+
+	results := runStream(t, push, 1, 10, func(w io.Writer) {
+		_, _ = io.WriteString(w, "/nix/store/first\n")
+		time.Sleep(50 * time.Millisecond)
+
+		_, _ = io.WriteString(w, "/nix/store/x\n/nix/store/y\n/nix/store/z\n")
+
+		time.Sleep(50 * time.Millisecond)
+
+		close(release)
+	})
+
+	if len(results) != 4 {
+		t.Fatalf("got %d results, want 4", len(results))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(batches) != 2 || len(batches[1]) != 3 {
+		t.Errorf("batches = %v, want [first] then [x y z]", batches)
+	}
+}
+
+func TestStreamPushIsolatesFailures(t *testing.T) {
+	t.Parallel()
+
+	errBad := errors.New("bad path")
+
+	push := func(_ context.Context, paths []string) ([]string, error) {
+		if slices.Contains(paths, "/nix/store/bad") {
+			return nil, errBad
+		}
+
+		return paths, nil
+	}
+
+	results := runStream(t, push, 1, 10, func(w io.Writer) {
+		_, _ = io.WriteString(w, "/nix/store/good1\n/nix/store/bad\n/nix/store/good2\n")
+	})
+
+	status := map[string]result{}
+	for _, r := range results {
+		status[r.Path] = r
+	}
+
+	for _, p := range []string{"/nix/store/good1", "/nix/store/good2"} {
+		if status[p].Status != "ok" {
+			t.Errorf("%s: %+v, want ok", p, status[p])
+		}
+	}
+
+	if bad := status["/nix/store/bad"]; bad.Status != "error" || !strings.Contains(bad.Message, "bad path") {
+		t.Errorf("bad: %+v, want error with message", bad)
+	}
+}
+
+func TestStreamPushGivesUpOnDeadServer(t *testing.T) {
+	t.Parallel()
+
+	errDown := errors.New("connection refused")
+
+	var calls int
+
+	push := func(_ context.Context, _ []string) ([]string, error) {
+		calls++
+
+		return nil, errDown
+	}
+
+	var sb strings.Builder
+	for i := range 20 {
+		sb.WriteString("/nix/store/p" + string(rune('a'+i)) + "\n")
+	}
+
+	results := runStream(t, push, 1, 50, func(w io.Writer) {
+		_, _ = io.WriteString(w, sb.String())
+	})
+
+	if len(results) != 20 {
+		t.Fatalf("got %d results, want 20", len(results))
+	}
+
+	for _, r := range results {
+		if r.Status != "error" {
+			t.Errorf("%s: status %s, want error", r.Path, r.Status)
+		}
+	}
+
+	if calls > 1+3 {
+		t.Errorf("push called %d times, want <= 4", calls)
+	}
+}

--- a/cmd/niks3/main.go
+++ b/cmd/niks3/main.go
@@ -36,8 +36,16 @@ func printUsage() {
 
 func printPushHelp() {
 	fmt.Fprintln(os.Stderr, "Usage: niks3 push [flags] <store-paths...>")
+	fmt.Fprintln(os.Stderr, "       niks3 push [flags] --stdin")
 	fmt.Fprintln(os.Stderr, "\nUpload Nix store paths to S3-compatible binary cache.")
 	fmt.Fprintln(os.Stderr, "\nFlags:")
+	fmt.Fprintln(os.Stderr, "  --stdin")
+	fmt.Fprintln(os.Stderr, "        Read store paths line by line from stdin and push them as they")
+	fmt.Fprintln(os.Stderr, "        arrive. Writes one JSON line per path to stdout:")
+	fmt.Fprintln(os.Stderr, `        {"path":"...","status":"ok"|"error","message":"..."}`)
+	fmt.Fprintln(os.Stderr, "        Exits after stdin is closed and everything was reported.")
+	fmt.Fprintf(os.Stderr, "  --batch-size int\n        With --stdin: max paths per push (default: %d)\n", client.DefaultStreamBatchSize)
+	fmt.Fprintf(os.Stderr, "  --parallel-pushes int\n        With --stdin: pushes running at once, each with up to\n        --max-concurrent-uploads NAR uploads (default: %d)\n", client.DefaultStreamParallel)
 	fmt.Fprintln(os.Stderr, "  --server-url string")
 	fmt.Fprintln(os.Stderr, "        Server URL (can also use NIKS3_SERVER_URL env var)")
 	fmt.Fprintln(os.Stderr, cmdutil.AuthTokenHelp)
@@ -97,6 +105,9 @@ func run() error {
 		maxConcurrent := pushCmd.Int("max-concurrent-uploads", 30, "Maximum concurrent uploads")
 		verifyS3Integrity := pushCmd.Bool("verify-s3-integrity", false, "Verify S3 integrity")
 		pinName := pushCmd.String("pin", "", "Create a named pin for the pushed closure")
+		fromStdin := pushCmd.Bool("stdin", false, "Stream store paths from stdin")
+		batchSize := pushCmd.Int("batch-size", client.DefaultStreamBatchSize, "Max paths per push with --stdin")
+		parallelPushes := pushCmd.Int("parallel-pushes", client.DefaultStreamParallel, "Concurrent pushes with --stdin")
 		tf := cmdutil.AddTLSFlags(pushCmd)
 
 		ts, err := cmdutil.ParseCommand(pushCmd, cf, tf, os.Args[2:], printPushHelp)
@@ -105,6 +116,15 @@ func run() error {
 		}
 
 		paths := pushCmd.Args()
+
+		if *fromStdin {
+			if len(paths) > 0 || *pinName != "" {
+				return errors.New("--stdin takes no store path arguments and no --pin")
+			}
+
+			return pushStdinCommand(*cf.ServerURL, ts, *maxConcurrent, *parallelPushes, *batchSize, *verifyS3Integrity, *cf.Debug, tf)
+		}
+
 		if len(paths) == 0 {
 			return errors.New("at least one store path is required")
 		}
@@ -212,6 +232,25 @@ func pushCommand(serverURL string, ts client.TokenSource, paths []string, maxCon
 	}
 
 	return nil
+}
+
+func pushStdinCommand(serverURL string, ts client.TokenSource, maxConcurrent, parallel, batchSize int, verifyS3Integrity bool, debug bool, tf cmdutil.TLSFlags) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+
+	c, err := cmdutil.NewClient(ctx, serverURL, ts, tf, debug)
+	if err != nil {
+		return err //nolint:wrapcheck // cmdutil errors are already user-facing
+	}
+
+	c.MaxConcurrentNARUploads = maxConcurrent
+	c.VerifyS3Integrity = verifyS3Integrity
+
+	return client.NewStreamPusher(c.PushPaths, parallel, batchSize).Run(ctx, os.Stdin, os.Stdout) //nolint:wrapcheck // already descriptive
 }
 
 func gcCommand(serverURL string, ts client.TokenSource, olderThan, pendingOlderThan string, force bool, debug bool, tf cmdutil.TLSFlags) error {

--- a/nix/checks/nixos-test-niks3.nix
+++ b/nix/checks/nixos-test-niks3.nix
@@ -262,6 +262,8 @@ testers.nixosTest {
   };
 
   testScript = ''
+    import json
+
     start_all()
 
     # Common test variables
@@ -351,6 +353,18 @@ testers.nixosTest {
       nix log --store '{binary_cache_url}' {test_output}
     """)
     assert "test build log output" in log_output, "Build log missing expected output"
+
+    with subtest("push --stdin streams paths and reports each one"):
+        stdin_path = server.succeed("nix-build --no-out-link -E 'derivation { name = \"stdin-test\"; system = builtins.currentSystem; builder = \"/bin/sh\"; args = [ \"-c\" \"echo stdin > $out\" ]; }'").strip()
+        out = server.succeed(f"printf '%s\\n\\n%s\\n' {stdin_path} {test_output} | {niks3_push_env} {niks3_cmd} push --stdin")
+        results = {r["path"]: r for r in map(json.loads, out.strip().splitlines())}
+        assert results[stdin_path]["status"] == "ok", results
+        assert results[test_output]["status"] == "ok", results
+        assert len(results) == 2, results
+        server.succeed(f"""
+          {s3_env}
+          nix copy --from '{binary_cache_url}' --to /tmp/stdin-store {stdin_path}
+        """)
   ''
   + (lib.optionalString ca-derivations-supported ''
     # Test CA (content-addressed) derivations with signature verification
@@ -513,7 +527,6 @@ testers.nixosTest {
     assert "hello-pin" in pins_names, f"Pin 'hello-pin' not found in names-only list: {pins_names}"
 
     # Test 3b: List pins with --json
-    import json
     pins_json = server.succeed("""
       NIKS3_SERVER_URL=http://server:5751 \
       NIKS3_AUTH_TOKEN_FILE=/tmp/test-config/auth-token \


### PR DESCRIPTION
CI drivers like nixbot keep building attributes for a long time and
want each output in the cache as soon as it exists. With one `niks3
push` per attribute they pay process start, auth and closure setup per
call; with one big batched push every attribute waits for the slowest
upload in the batch.

--stdin keeps one process per session: paths are pushed as they arrive
on stdin, several pushes run in parallel, bursts are coalesced into
batches, and each input path is acknowledged with a JSON line on stdout
once its closure is committed. A failing batch is retried path by path
so one bad path does not fail its neighbours.
