### PR TITLE
Fix macOS case-hack handling in NAR serialization

### DIFF
--- a/client/export_test.go
+++ b/client/export_test.go
@@ -27,6 +27,14 @@ const MultipartPartSize = multipartPartSize
 // ScriptTokenWithClock builds a ScriptToken with an injected clock for tests.
 var ScriptTokenWithClock = scriptToken //nolint:gochecknoglobals // test-only re-export
 
+// SetUseCaseHack forces macOS case-hack handling for tests and returns the old value.
+func SetUseCaseHack(on bool) bool {
+	old := useCaseHack
+	useCaseHack = on
+
+	return old
+}
+
 // HTTPClient exposes the underlying http.Client for testing.
 func (c *Client) HTTPClient() *http.Client {
 	return c.httpClient

--- a/client/nar.go
+++ b/client/nar.go
@@ -52,15 +52,14 @@ var (
 	targetEncoded          = encodeStaticString("target")
 )
 
-// stripCaseHackSuffix removes the case hack suffix from filenames on macOS.
+// stripCaseHackSuffix undoes Nix's macOS case hack: everything from the
+// first marker on is dropped, as in libutil's dumpPath.
 func stripCaseHackSuffix(name string) string {
 	if !useCaseHack {
 		return name
 	}
 
-	if strings.HasSuffix(name, caseHackSuffix) {
-		return name[:len(name)-len(caseHackSuffix)]
-	}
+	name, _, _ = strings.Cut(name, caseHackSuffix)
 
 	return name
 }
@@ -390,11 +389,6 @@ func walkDirectory(path, name string) (*narNode, error) {
 		return nil, fmt.Errorf("reading directory %s: %w", path, err)
 	}
 
-	// Sort entries by name (NAR requirement)
-	slices.SortFunc(entries, func(a, b os.DirEntry) int {
-		return strings.Compare(a.Name(), b.Name())
-	})
-
 	node := &narNode{name: name, path: path, kind: 'd', children: make([]*narNode, 0, len(entries))}
 
 	for _, entry := range entries {
@@ -438,6 +432,19 @@ func walkDirectory(path, name string) (*narNode, error) {
 		}
 
 		node.children = append(node.children, child)
+	}
+
+	// NAR orders entries by the name inside the archive, which differs from
+	// the on-disk name once the case-hack suffix is stripped.
+	slices.SortFunc(node.children, func(a, b *narNode) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	for i := 1; i < len(node.children); i++ {
+		if node.children[i-1].name == node.children[i].name {
+			return nil, fmt.Errorf("file name collision between %s and %s",
+				node.children[i-1].path, node.children[i].path)
+		}
 	}
 
 	return node, nil

--- a/client/nar_case_hack_test.go
+++ b/client/nar_case_hack_test.go
@@ -1,0 +1,77 @@
+package client_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mic92/niks3/client"
+)
+
+func caseHackDir(t *testing.T, names ...string) string {
+	t.Helper()
+
+	saved := client.SetUseCaseHack(true)
+
+	t.Cleanup(func() { client.SetUseCaseHack(saved) })
+
+	// nix-store --dump refuses symlinked prefixes (macOS /var -> /private/var).
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range names {
+		err := os.WriteFile(filepath.Join(root, name), []byte(name), 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return root
+}
+
+//nolint:paralleltest // flips the useCaseHack global
+func TestDumpPathCaseHackMatchesNix(t *testing.T) {
+	if _, err := exec.LookPath("nix-store"); err != nil {
+		t.Skip("nix-store not available")
+	}
+
+	root := caseHackDir(t,
+		"XT_CONNMARK.h",
+		"xt_connmark.h~nix~case~hack~1",
+		"Xt_connmark.h~nix~case~hack~2",
+		"a!", // sorts between "a" and "a~"
+		"a~nix~case~hack~12",
+		"c~nix~case~hack~x~nix~case~hack~2",
+	)
+
+	var got bytes.Buffer
+
+	_, err := client.DumpPathWithListing(&got, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := exec.CommandContext(t.Context(),
+		"nix-store", "--option", "use-case-hack", "true", "--dump", root).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatalf("NAR differs from nix-store --dump: %d vs %d bytes", got.Len(), len(want))
+	}
+}
+
+//nolint:paralleltest // flips the useCaseHack global
+func TestDumpPathCaseHackCollision(t *testing.T) {
+	root := caseHackDir(t, "same", "same~nix~case~hack~1")
+
+	_, err := client.DumpPathWithListing(&bytes.Buffer{}, root)
+	if err == nil {
+		t.Fatal("expected file name collision")
+	}
+}


### PR DESCRIPTION
On macOS, Nix escapes case-conflicting filenames using suffixes like:

```
xt_connmark.h~nix~case~hack~1
```

niks3 wasn't restoring these names the same way as Nix when writing NARs. In particular, it only handled a case-hack marker at the end of the filename, and sorted entries before restoring their names.

This could make niks3 upload NAR bytes that don't match the canonical NAR hash for the store path. I hit this with:

```
/nix/store/zv0vms3wlmnpryhxji2zizfkg4f8fmk8-linux-headers-6.18.7
```

where the generated archive differed from `nix-store --dump` at eight case-hacked filenames.

Match Nix's handling in [`SourceAccessor::dumpPath`](https://github.com/NixOS/nix/blob/8aad447f0bace6be413963e897ad690247ad6aa2/src/libutil/archive.cc#L85-L100):
* strip the first `~nix~case~hack~` marker and everything after it
* sort directory entries by the restored name
* reject collisions after restoration

Also adds regression tests comparing the generated NAR directly against `nix-store --dump`.