### PR TITLE
server: page GC deletions by key and settle batch delete errors per key

### DIFF
--- a/server/gc_batch_delete_test.go
+++ b/server/gc_batch_delete_test.go
@@ -1,0 +1,240 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mic92/niks3/api"
+	"github.com/Mic92/niks3/server"
+	"github.com/minio/minio-go/v7"
+)
+
+// deleteObservingProxy sits between the service and RustFS. It records every
+// key named in a DeleteObjects request and every single DeleteObject. With
+// failMultiDelete set it forwards each DeleteObjects request and then answers
+// with a bucket level InternalError, which is what Fastly Object Storage does
+// when any key in the batch is missing: the keys that existed are deleted and
+// the response names none of them.
+type deleteObservingProxy struct {
+	proxy           *httputil.ReverseProxy
+	failMultiDelete bool
+
+	mu         sync.Mutex
+	batchKeys  []string
+	singleKeys []string
+}
+
+type deleteObjectsRequest struct {
+	Objects []struct {
+		Key string `xml:"Key"`
+	} `xml:"Object"`
+}
+
+func newDeleteObservingProxy(tb testing.TB, failMultiDelete bool) *deleteObservingProxy {
+	tb.Helper()
+
+	target, err := url.Parse(fmt.Sprintf("http://localhost:%d", testRustfsServer.port))
+	ok(tb, err)
+
+	return &deleteObservingProxy{
+		proxy:           httputil.NewSingleHostReverseProxy(target),
+		failMultiDelete: failMultiDelete,
+	}
+}
+
+func (p *deleteObservingProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Query().Has("delete"):
+		p.serveMultiDelete(w, r)
+
+		return
+	case r.Method == http.MethodDelete:
+		p.mu.Lock()
+		p.singleKeys = append(p.singleKeys, r.URL.Path)
+		p.mu.Unlock()
+	}
+
+	p.proxy.ServeHTTP(w, r)
+}
+
+func (p *deleteObservingProxy) serveMultiDelete(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	var req deleteObjectsRequest
+	if err := xml.Unmarshal(body, &req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
+	p.mu.Lock()
+	for _, obj := range req.Objects {
+		p.batchKeys = append(p.batchKeys, obj.Key)
+	}
+	p.mu.Unlock()
+
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	if !p.failMultiDelete {
+		p.proxy.ServeHTTP(w, r)
+
+		return
+	}
+
+	// delete the keys that exist, then hide the outcome behind a bucket level error
+	p.proxy.ServeHTTP(httptest.NewRecorder(), r)
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>InternalError</Code><Message>Internal error.</Message><Resource>/bucket</Resource></Error>`))
+}
+
+// seedExpiredOrphans uploads count objects and inserts them as unreachable
+// rows whose grace period has already passed.
+func seedExpiredOrphans(tb testing.TB, service *server.Service, prefix string, count int) []string {
+	tb.Helper()
+
+	ctx := tb.Context()
+	keys := make([]string, 0, count)
+
+	for i := range count {
+		key := fmt.Sprintf("%s%030d.narinfo", prefix, i)
+
+		_, err := service.MinioClient.PutObject(ctx, service.Bucket, key, strings.NewReader("x"), 1, minio.PutObjectOptions{})
+		ok(tb, err)
+
+		_, err = service.Pool.Exec(ctx,
+			`INSERT INTO objects (key, refs, deleted_at, first_deleted_at)
+			 VALUES ($1, '{}', timezone('UTC', now()) - interval '1 hour', timezone('UTC', now()) - interval '1 hour')`,
+			key)
+		ok(tb, err)
+
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func assertGCDeletedAll(tb testing.TB, status api.GCTaskStatus, count int) {
+	tb.Helper()
+
+	if status.State != api.GCTaskStateSucceeded {
+		tb.Fatalf("gc ended in state %s: %s", status.State, status.Error)
+	}
+
+	if status.Stats.ObjectsDeletedAfterGracePeriod != count || status.Stats.ObjectsFailedToDelete != 0 {
+		tb.Fatalf("expected %d deleted and 0 failed, got %d deleted and %d failed",
+			count, status.Stats.ObjectsDeletedAfterGracePeriod, status.Stats.ObjectsFailedToDelete)
+	}
+}
+
+func assertObjectsGone(tb testing.TB, service *server.Service, keys []string) {
+	tb.Helper()
+
+	ctx := tb.Context()
+
+	var remaining int
+
+	err := service.Pool.QueryRow(ctx, "SELECT count(*) FROM objects WHERE key = ANY($1)", keys).Scan(&remaining)
+	ok(tb, err)
+
+	if remaining != 0 {
+		tb.Fatalf("%d of %d rows remain in the database", remaining, len(keys))
+	}
+
+	for _, key := range []string{keys[0], keys[len(keys)-1]} {
+		_, err := service.MinioClient.StatObject(ctx, service.Bucket, key, minio.StatObjectOptions{})
+		if minio.ToErrorResponse(err).Code != minio.NoSuchKey {
+			tb.Fatalf("object %s is still present or failed differently: %v", key, err)
+		}
+	}
+}
+
+// TestOrphanedObjectsGCDeletesEachKeyOnce checks that the producer never hands
+// the same key to S3 twice. Fetching the next page with a plain LIMIT while the
+// previous batch had not been flushed to the database returned the previous
+// page again and sent every key several times.
+func TestOrphanedObjectsGCDeletesEachKeyOnce(t *testing.T) {
+	t.Parallel()
+
+	proxy := newDeleteObservingProxy(t, false)
+	proxyServer := httptest.NewServer(proxy)
+
+	defer proxyServer.Close()
+
+	service := createTestServiceWithThrottlingProxy(t, proxyServer.URL)
+	defer service.Close()
+
+	const count = 2*server.DeletionBatchSize + 500
+
+	keys := seedExpiredOrphans(t, service, "once", count)
+
+	status := service.RunGCForTest(24*time.Hour, 0, false)
+	assertGCDeletedAll(t, status, count)
+
+	proxy.mu.Lock()
+	seen := slices.Clone(proxy.batchKeys)
+	proxy.mu.Unlock()
+
+	slices.Sort(seen)
+
+	if unique := slices.Compact(slices.Clone(seen)); len(unique) != len(seen) {
+		t.Fatalf("%d keys were sent to S3 more than once", len(seen)-len(unique))
+	}
+
+	if len(seen) != count {
+		t.Fatalf("expected %d keys in DeleteObjects requests, saw %d", count, len(seen))
+	}
+
+	assertObjectsGone(t, service, keys)
+}
+
+// TestOrphanedObjectsGCFallsBackToSingleDeletes checks that a bucket level
+// error on DeleteObjects, which minio reports for every key in the batch, is
+// settled per key with DeleteObject instead of re-activating rows for objects
+// that S3 has already removed.
+func TestOrphanedObjectsGCFallsBackToSingleDeletes(t *testing.T) {
+	t.Parallel()
+
+	proxy := newDeleteObservingProxy(t, true)
+	proxyServer := httptest.NewServer(proxy)
+
+	defer proxyServer.Close()
+
+	service := createTestServiceWithThrottlingProxy(t, proxyServer.URL)
+	defer service.Close()
+
+	const count = server.DeletionBatchSize + 500
+
+	keys := seedExpiredOrphans(t, service, "fallback", count)
+
+	status := service.RunGCForTest(24*time.Hour, 0, false)
+	assertGCDeletedAll(t, status, count)
+
+	proxy.mu.Lock()
+	singles := len(proxy.singleKeys)
+	proxy.mu.Unlock()
+
+	if singles != count {
+		t.Fatalf("expected %d single deletes after the batch errors, saw %d", count, singles)
+	}
+
+	assertObjectsGone(t, service, keys)
+}

--- a/server/objects_model.go
+++ b/server/objects_model.go
@@ -62,10 +62,17 @@ func (s *Service) getObjectsForDeletion(ctx context.Context,
 		onProgress(*stats)
 	}
 
-	// Then, get objects ready for deletion (marked > gracePeriod ago)
+	// Then, get objects ready for deletion (marked > gracePeriod ago).
+	// The consumer removes or re-activates rows only after a full batch, so
+	// pages are keyed on the last key handed out. Re-running a plain LIMIT
+	// query would return the previous page again while its batch is still
+	// in flight and send the same keys to S3 twice.
+	afterKey := ""
+
 	for {
 		objs, err := queries.GetObjectsReadyForDeletion(ctx, pg.GetObjectsReadyForDeletionParams{
 			GracePeriodSeconds: gracePeriod,
+			AfterKey:           afterKey,
 			LimitCount:         DeletionBatchSize,
 		})
 		if err != nil {
@@ -78,6 +85,8 @@ func (s *Service) getObjectsForDeletion(ctx context.Context,
 		if len(objs) == 0 {
 			break
 		}
+
+		afterKey = objs[len(objs)-1]
 
 		for _, obj := range objs {
 			select {
@@ -123,6 +132,35 @@ func handleFailedObject(ctx context.Context, objectName string, resultErr error,
 	return failedKeys, s3Errors, nil
 }
 
+// removeObjectSingle deletes one key with DeleteObject after a batch delete
+// reported it as failed. A batch error is reported for every key in the batch
+// and says nothing about the individual key: some S3 implementations fail the
+// whole DeleteObjects request when any key in it is missing while still
+// deleting the others. The single delete answers per key, and a key that is
+// already gone counts as deleted.
+func (s *Service) removeObjectSingle(ctx context.Context, key string) error {
+	if err := s.S3RateLimiter.Wait(ctx); err != nil {
+		return fmt.Errorf("waiting for rate limiter: %w", err)
+	}
+
+	err := s.MinioClient.RemoveObject(ctx, s.Bucket, key, minio.RemoveObjectOptions{})
+	if err != nil {
+		if isRateLimitError(err) {
+			s.S3RateLimiter.RecordThrottle()
+		}
+
+		if minio.ToErrorResponse(err).Code == minio.NoSuchKey {
+			return nil
+		}
+
+		return fmt.Errorf("single delete after batch failure: %w", err)
+	}
+
+	s.S3RateLimiter.RecordSuccess()
+
+	return nil
+}
+
 func (s *Service) removeS3Objects(ctx context.Context,
 	objectCh <-chan minio.ObjectInfo,
 	stats *ObjectCleanupStats,
@@ -143,34 +181,34 @@ func (s *Service) removeS3Objects(ctx context.Context,
 	var s3Errors, batchErrors []error
 
 	for result := range s.MinioClient.RemoveObjectsWithResult(ctx, s.Bucket, objectCh, opts) {
-		if result.Err != nil {
+		removeErr := result.Err
+
+		switch {
+		case removeErr == nil:
+			s.S3RateLimiter.RecordSuccess()
+		case minio.ToErrorResponse(removeErr).Code == minio.NoSuchKey:
+			// If object doesn't exist in S3, treat it as successfully deleted
+			// to maintain consistency between S3 and database
+			removeErr = nil
+		default:
 			// Track rate limit errors to enable adaptive rate limiting
-			if isRateLimitError(result.Err) {
+			if isRateLimitError(removeErr) {
 				s.S3RateLimiter.RecordThrottle()
 			}
 
-			// If object doesn't exist in S3, treat it as successfully deleted
-			// to maintain consistency between S3 and database
-			if minio.ToErrorResponse(result.Err).Code == minio.NoSuchKey {
-				var err error
+			slog.Debug("batch delete failed for object, retrying with a single delete",
+				"object", result.ObjectName, "error", removeErr)
 
-				deletedKeys, err = handleDeletedObject(ctx, result.ObjectName, deletedKeys, queries)
-				if err != nil {
-					batchErrors = append(batchErrors, err)
-				}
+			removeErr = s.removeObjectSingle(ctx, result.ObjectName)
+		}
 
-				stats.DeletedCount++
-				notifyProgress()
-
-				continue
-			}
-
+		if removeErr != nil {
 			var (
 				newS3Errors []error
 				err         error
 			)
 
-			failedKeys, newS3Errors, err = handleFailedObject(ctx, result.ObjectName, result.Err, failedKeys, queries)
+			failedKeys, newS3Errors, err = handleFailedObject(ctx, result.ObjectName, removeErr, failedKeys, queries)
 
 			s3Errors = append(s3Errors, newS3Errors...)
 			if err != nil {
@@ -182,8 +220,6 @@ func (s *Service) removeS3Objects(ctx context.Context,
 
 			continue
 		}
-
-		s.S3RateLimiter.RecordSuccess()
 
 		var err error
 

--- a/server/pg/query.sql
+++ b/server/pg/query.sql
@@ -203,12 +203,16 @@ FROM stale_objects, ct
 WHERE objects.key = stale_objects.key;
 
 -- name: GetObjectsReadyForDeletion :many
--- Returns objects marked for >= grace_period, safe to delete from S3
+-- Returns objects marked for >= grace_period, safe to delete from S3.
+-- Keyset paginated on key so a caller that has not yet removed or re-activated
+-- the previous page never receives the same key twice.
 SELECT key
 FROM objects
 WHERE first_deleted_at IS NOT NULL
   AND deleted_at IS NOT NULL
   AND first_deleted_at <= timezone('UTC', now()) - interval '1 second' * sqlc.arg(grace_period_seconds)::int
+  AND key > sqlc.arg(after_key)::varchar
+ORDER BY key
 LIMIT sqlc.arg(limit_count);
 
 -- name: GetClosureForShare :one

--- a/server/pg/query.sql.go
+++ b/server/pg/query.sql.go
@@ -268,17 +268,22 @@ FROM objects
 WHERE first_deleted_at IS NOT NULL
   AND deleted_at IS NOT NULL
   AND first_deleted_at <= timezone('UTC', now()) - interval '1 second' * $1::int
-LIMIT $2
+  AND key > $2::varchar
+ORDER BY key
+LIMIT $3
 `
 
 type GetObjectsReadyForDeletionParams struct {
-	GracePeriodSeconds int32 `json:"grace_period_seconds"`
-	LimitCount         int32 `json:"limit_count"`
+	GracePeriodSeconds int32  `json:"grace_period_seconds"`
+	AfterKey           string `json:"after_key"`
+	LimitCount         int32  `json:"limit_count"`
 }
 
-// Returns objects marked for >= grace_period, safe to delete from S3
+// Returns objects marked for >= grace_period, safe to delete from S3.
+// Keyset paginated on key so a caller that has not yet removed or re-activated
+// the previous page never receives the same key twice.
 func (q *Queries) GetObjectsReadyForDeletion(ctx context.Context, arg GetObjectsReadyForDeletionParams) ([]string, error) {
-	rows, err := q.db.Query(ctx, getObjectsReadyForDeletion, arg.GracePeriodSeconds, arg.LimitCount)
+	rows, err := q.db.Query(ctx, getObjectsReadyForDeletion, arg.GracePeriodSeconds, arg.AfterKey, arg.LimitCount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
disclosure: LLM assisted, i'm still trying to test this on my deployment, please don't merge yet

## Problem

Observed on a niks3 1.10.1 server whose bucket lives on Fastly Object Storage. The daily GC failed with `16961 S3 failures: failed to remove object ...: Internal error.` after 22 minutes, and afterwards 2141 rows in `objects` were active (`deleted_at = NULL`) for keys that no longer existed in the bucket.

Two things combine:

1. `getObjectsForDeletion` fetches pages with a plain `LIMIT 1000` and no ordering, and the consumer only deletes or re-activates rows after a full batch of 1000 results. The second page is therefore queried while the first batch is still in flight and returns the same keys again. In the run above, 4141 distinct keys produced about 19000 delete results.
2. Fastly Object Storage answers a `DeleteObjects` request that names any missing key with a bucket level `500 InternalError`, after deleting the keys that did exist (verified with two-key requests via curl; a single `DeleteObject` of a missing key returns 204 as expected). minio reports such an error for every key in the batch, `handleFailedObject` collects them and `MarkObjectsAsActive` re-activates rows for objects Fastly has already deleted. The next run marks them stale again, waits out the grace period, fails on the same keys again, and so on.

Against a backend with S3 semantics the duplicates are silent, since a second delete of a missing key succeeds, which is why this never showed on B2 or RustFS.

## Change

- `GetObjectsReadyForDeletion` is keyset paginated: `AND key > $after_key ORDER BY key`. The producer passes the last key of the previous page, so a key is handed to S3 at most once per run regardless of when the consumer flushes.
- When a batch result carries an error other than `NoSuchKey`, the consumer retries that key with a single `RemoveObject`, which answers per key. A missing key counts as deleted. Only a key whose single delete fails with a real error is re-activated. Batch successes are unchanged.

Either half alone would have avoided the state above: the first by never sending a duplicate, the second by never trusting a bucket level error per key.

## Tests

`gc_batch_delete_test.go` adds a proxy in front of RustFS that records the keys of every `DeleteObjects` and `DeleteObject` request and can mimic Fastly by forwarding the batch and then answering `InternalError`.

- `TestOrphanedObjectsGCDeletesEachKeyOnce`: 2500 expired orphans, asserts every key is sent once. On the old code the GC reports 11500 deletions.
- `TestOrphanedObjectsGCFallsBackToSingleDeletes`: 1500 expired orphans behind the failing proxy, asserts the run succeeds with one single delete per key and no rows or objects left. On the old code it fails with `7500 S3 failures ... Internal error.`

`golangci-lint run --new-from-rev` reports only `exhaustruct_v5` on the minio option structs, the same pattern the existing calls use.
