### PR TITLE
nix: fix pkgs.system warning and darwin treefmt hang

### DIFF
--- a/nix/checks/nixos-test-k3s.nix
+++ b/nix/checks/nixos-test-k3s.nix
@@ -8,11 +8,11 @@
   k3s,
   niks3,
   niks3-docker,
-  system,
+  stdenv,
   ...
 }:
 let
-  image = niks3-docker.perArch.${system};
+  image = niks3-docker.perArch.${stdenv.hostPlatform.system};
 
   chart = runCommand "niks3-chart.tgz" { nativeBuildInputs = [ kubernetes-helm ]; } ''
     cp -r ${../../deploy/helm/niks3} chart


### PR DESCRIPTION
callPackage filled `system` from pkgs.system, which nixpkgs now warns about.
