### PR TITLE
treefmt: run sqlfluff single-process

### DIFF
--- a/nix/formatter/default.nix
+++ b/nix/formatter/default.nix
@@ -16,6 +16,15 @@ let
     programs.sqlfluff.enable = true;
     programs.sqlfluff.dialect = "postgres";
     programs.sqlfluff.excludes = [ "server/pg/query.sql" ];
+    # treefmt-nix passes --processes 0. The multiprocessing pool hangs in
+    # the macOS sandbox after the workers exit, and six files need no pool.
+    settings.formatter.sqlfluff.options = pkgs.lib.mkForce [
+      "format"
+      "--disable-progress-bar"
+      "--processes"
+      "1"
+      "--dialect=postgres"
+    ];
     programs.rustfmt.enable = true;
     programs.rustfmt.edition = "2021";
   };


### PR DESCRIPTION
With --processes 0 sqlfluff forks a multiprocessing pool that never gets
reaped inside the macOS sandbox, so the darwin treefmt check hangs with
a dozen defunct workers.
